### PR TITLE
Add a reversible Xcode 27 simulator host switcher

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    # actionlint 1.7.12 does not yet know GitHub's hosted Xcode 27 preview label.
+    - xcode-27

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,19 +30,14 @@ concurrency:
 jobs:
   package:
     name: Package (macOS)
-    runs-on: macos-26
+    runs-on: xcode-27
     timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      - name: Select latest Xcode
+      - name: Show Xcode toolchain
         run: |
-          set -euo pipefail
-          xcode_path="$(
-            ruby -e 'candidates = Dir["/Applications/Xcode*.app"].filter_map { |path| version = File.basename(path)[/\AXcode[_-](\d+(?:\.\d+)*)\.app\z/, 1]; version ? [version.split(".").map(&:to_i), path] : nil }; abort "No versioned Xcode apps found" if candidates.empty?; puts candidates.max_by(&:first).last'
-          )"
-          sudo xcode-select -s "${xcode_path}/Contents/Developer"
           xcodebuild -version
           swift --version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  workflow_call:
+    inputs:
+      concurrency_group:
+        description: Concurrency group override for callers.
+        required: false
+        type: string
+        default: ""
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - README.md
+      - LICENSE
+  pull_request:
+    paths-ignore:
+      - README.md
+      - LICENSE
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ inputs.concurrency_group || format('ci-{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  package:
+    name: Package (macOS)
+    runs-on: macos-26
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Select latest Xcode
+        run: |
+          set -euo pipefail
+          xcode_path="$(
+            ruby -e 'candidates = Dir["/Applications/Xcode*.app"].filter_map { |path| version = File.basename(path)[/\AXcode[_-](\d+(?:\.\d+)*)\.app\z/, 1]; version ? [version.split(".").map(&:to_i), path] : nil }; abort "No versioned Xcode apps found" if candidates.empty?; puts candidates.max_by(&:first).last'
+          )"
+          sudo xcode-select -s "${xcode_path}/Contents/Developer"
+          xcodebuild -version
+          swift --version
+
+      - name: Test
+        run: swift test
+
+      - name: Build release product
+        run: swift build -c release --product xcode-simulator-host
+
+      - name: Validate distribution scripts
+        run: |
+          bash -n \
+            scripts/build-release.sh \
+            scripts/package-release.sh \
+            scripts/render-install-script.sh \
+            scripts/verify-release-assets.sh
+          sh -n scripts/install-release.sh.in

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,283 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release tag to create
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  verify-release:
+    name: Verify Release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Verify release input
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_VERSION}" =~ ^v[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release tag must look like v1.2.3 or v1.2.3-rc.1." >&2
+            exit 1
+          fi
+          if [[ "${GITHUB_REF_TYPE}" != "branch" || "${GITHUB_REF_NAME}" != "${RELEASE_BRANCH}" ]]; then
+            echo "Release workflow must be dispatched from ${RELEASE_BRANCH}." >&2
+            exit 1
+          fi
+          remote_head="$(git ls-remote origin "refs/heads/${RELEASE_BRANCH}" | awk '{ print $1 }')"
+          if [[ -z "${remote_head}" || "${remote_head}" != "${GITHUB_SHA}" ]]; then
+            echo "Release workflow must run against the current ${RELEASE_BRANCH} head." >&2
+            echo "Remote head: ${remote_head:-missing}" >&2
+            echo "Workflow SHA: ${GITHUB_SHA}" >&2
+            exit 1
+          fi
+          remote_tag_target() {
+            git ls-remote --tags origin "refs/tags/${RELEASE_VERSION}" "refs/tags/${RELEASE_VERSION}^{}" |
+              awk '$2 ~ /\^\{\}$/ { peeled = $1 } $2 !~ /\^\{\}$/ { direct = $1 } END { if (peeled != "") print peeled; else if (direct != "") print direct }'
+          }
+          tag_target="$(remote_tag_target)"
+          if [[ -n "${tag_target}" && "${tag_target}" != "${GITHUB_SHA}" ]]; then
+            echo "Release tag already exists for a different commit: ${RELEASE_VERSION}" >&2
+            exit 1
+          fi
+          if release_info="$(gh release view "${RELEASE_VERSION}" --repo "${GITHUB_REPOSITORY}" --json isDraft,targetCommitish 2>/dev/null)"; then
+            release_is_draft="$(jq -r '.isDraft' <<< "${release_info}")"
+            release_target="$(jq -r '.targetCommitish' <<< "${release_info}")"
+            if [[ "${release_is_draft}" != "true" ]]; then
+              echo "GitHub Release already exists and is not a draft: ${RELEASE_VERSION}" >&2
+              exit 1
+            fi
+            if [[ "${release_target}" != "${GITHUB_SHA}" ]]; then
+              echo "Draft release targets a different commit: ${RELEASE_VERSION}" >&2
+              echo "Draft target: ${release_target}" >&2
+              echo "Workflow SHA: ${GITHUB_SHA}" >&2
+              exit 1
+            fi
+            echo "Existing draft release will be repaired: ${RELEASE_VERSION}"
+          fi
+
+  package-checks:
+    name: Package Checks
+    needs: verify-release
+    permissions:
+      contents: read
+    uses: ./.github/workflows/ci.yml
+    with:
+      concurrency_group: release-package-checks-${{ inputs.version }}
+
+  build-release:
+    name: Build Release
+    needs: package-checks
+    runs-on: macos-26
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      archive_sha256: ${{ steps.release_digests.outputs.archive_sha256 }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Select latest Xcode
+        run: |
+          set -euo pipefail
+          xcode_path="$(
+            ruby -e 'candidates = Dir["/Applications/Xcode*.app"].filter_map { |path| version = File.basename(path)[/\AXcode[_-](\d+(?:\.\d+)*)\.app\z/, 1]; version ? [version.split(".").map(&:to_i), path] : nil }; abort "No versioned Xcode apps found" if candidates.empty?; puts candidates.max_by(&:first).last'
+          )"
+          sudo xcode-select -s "${xcode_path}/Contents/Developer"
+          xcodebuild -version
+          swift --version
+
+      - name: Build release binary
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: scripts/build-release.sh --version "${RELEASE_VERSION}" --dist-root dist
+
+      - name: Package release assets
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          scripts/package-release.sh \
+            --version "${RELEASE_VERSION}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --dist-root dist \
+            --output-dir release
+
+      - name: Verify release assets
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          scripts/verify-release-assets.sh \
+            --version "${RELEASE_VERSION}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --release-dir release
+
+      - name: Record trusted release digest
+        id: release_digests
+        run: |
+          set -euo pipefail
+          archive_sha256="$(shasum -a 256 release/xcode-simulator-host-darwin-arm64.tar.gz | awk '{ print $1 }')"
+          echo "archive_sha256=${archive_sha256}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload release assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-assets
+          path: |
+            release/xcode-simulator-host-darwin-arm64.tar.gz
+            release/SHA256SUMS.txt
+            release/install.sh
+          if-no-files-found: error
+
+  create-draft-release:
+    name: Create Draft Release
+    needs: build-release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Download release assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-assets
+          path: release
+
+      - name: Verify release target
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_TYPE}" != "branch" || "${GITHUB_REF_NAME}" != "${RELEASE_BRANCH}" ]]; then
+            echo "Release workflow must be dispatched from ${RELEASE_BRANCH}." >&2
+            exit 1
+          fi
+          remote_head="$(git ls-remote origin "refs/heads/${RELEASE_BRANCH}" | awk '{ print $1 }')"
+          if [[ -z "${remote_head}" || "${remote_head}" != "${GITHUB_SHA}" ]]; then
+            echo "Release workflow must still target the current ${RELEASE_BRANCH} head." >&2
+            exit 1
+          fi
+
+      - name: Verify downloaded release assets
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          scripts/verify-release-assets.sh \
+            --version "${RELEASE_VERSION}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --release-dir release \
+            --archive-sha256 "${{ needs.build-release.outputs.archive_sha256 }}"
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          remote_tag_target() {
+            git ls-remote --tags origin "refs/tags/${RELEASE_VERSION}" "refs/tags/${RELEASE_VERSION}^{}" |
+              awk '$2 ~ /\^\{\}$/ { peeled = $1 } $2 !~ /\^\{\}$/ { direct = $1 } END { if (peeled != "") print peeled; else if (direct != "") print direct }'
+          }
+          is_expected_asset() {
+            case "$1" in
+              xcode-simulator-host-darwin-arm64.tar.gz|SHA256SUMS.txt|install.sh)
+                return 0
+                ;;
+              *)
+                return 1
+                ;;
+            esac
+          }
+
+          tag_target="$(remote_tag_target)"
+          if [[ -n "${tag_target}" && "${tag_target}" != "${GITHUB_SHA}" ]]; then
+            echo "Release tag already exists for a different commit: ${RELEASE_VERSION}" >&2
+            exit 1
+          fi
+
+          if release_info="$(gh release view "${RELEASE_VERSION}" --repo "${GITHUB_REPOSITORY}" --json isDraft,targetCommitish 2>/dev/null)"; then
+            release_is_draft="$(jq -r '.isDraft' <<< "${release_info}")"
+            release_target="$(jq -r '.targetCommitish' <<< "${release_info}")"
+            if [[ "${release_is_draft}" != "true" ]]; then
+              echo "GitHub Release already exists and is not a draft: ${RELEASE_VERSION}" >&2
+              exit 1
+            fi
+            if [[ "${release_target}" != "${GITHUB_SHA}" ]]; then
+              echo "Draft release targets a different commit: ${RELEASE_VERSION}" >&2
+              echo "Draft target: ${release_target}" >&2
+              echo "Workflow SHA: ${GITHUB_SHA}" >&2
+              exit 1
+            fi
+
+            if [[ "${RELEASE_VERSION}" == *-* ]]; then
+              gh release edit "${RELEASE_VERSION}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --prerelease \
+                --latest=false
+            else
+              gh release edit "${RELEASE_VERSION}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --prerelease=false
+            fi
+
+            while IFS= read -r asset_name; do
+              [[ -n "${asset_name}" ]] || continue
+              if ! is_expected_asset "${asset_name}"; then
+                gh release delete-asset "${RELEASE_VERSION}" "${asset_name}" --repo "${GITHUB_REPOSITORY}" --yes
+              fi
+            done < <(gh release view "${RELEASE_VERSION}" --repo "${GITHUB_REPOSITORY}" --json assets --jq '.assets[].name')
+
+            gh release upload "${RELEASE_VERSION}" \
+              release/xcode-simulator-host-darwin-arm64.tar.gz \
+              release/SHA256SUMS.txt \
+              release/install.sh \
+              --repo "${GITHUB_REPOSITORY}" \
+              --clobber
+
+            echo "Repaired draft release ${RELEASE_VERSION}."
+          else
+            release_classification=()
+            if [[ "${RELEASE_VERSION}" == *-* ]]; then
+              release_classification+=(--prerelease --latest=false)
+            fi
+            gh release create "${RELEASE_VERSION}" \
+              release/xcode-simulator-host-darwin-arm64.tar.gz \
+              release/SHA256SUMS.txt \
+              release/install.sh \
+              --repo "${GITHUB_REPOSITORY}" \
+              --draft \
+              --generate-notes \
+              --target "${GITHUB_SHA}" \
+              --title "${RELEASE_VERSION}" \
+              "${release_classification[@]}"
+
+            echo "Created draft release ${RELEASE_VERSION}."
+          fi
+          echo "Edit the release notes, then publish the draft manually."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
   build-release:
     name: Build Release
     needs: package-checks
-    runs-on: macos-26
+    runs-on: xcode-27
     timeout-minutes: 10
     permissions:
       contents: read
@@ -99,13 +99,8 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
-      - name: Select latest Xcode
+      - name: Show Xcode toolchain
         run: |
-          set -euo pipefail
-          xcode_path="$(
-            ruby -e 'candidates = Dir["/Applications/Xcode*.app"].filter_map { |path| version = File.basename(path)[/\AXcode[_-](\d+(?:\.\d+)*)\.app\z/, 1]; version ? [version.split(".").map(&:to_i), path] : nil }; abort "No versioned Xcode apps found" if candidates.empty?; puts candidates.max_by(&:first).last'
-          )"
-          sudo xcode-select -s "${xcode_path}/Contents/Developer"
           xcodebuild -version
           swift --version
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ xcuserdata/
 DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.swiftpm/xcode/xcshareddata/xcschemes/
 .netrc

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 /.build
+/dist
+/release
 /Packages
 xcuserdata/
 DerivedData/

--- a/Documentation/Design.md
+++ b/Documentation/Design.md
@@ -9,7 +9,7 @@ used alongside Xcode 27 simulator runs.
 xcode-simulator-host status
 xcode-simulator-host use legacy [--legacy-xcode /Applications/Xcode.app]
 xcode-simulator-host use device-hub
-xcode-simulator-host restore
+xcode-simulator-host restore [--force]
 ```
 
 - `status` is read-only.
@@ -21,6 +21,8 @@ xcode-simulator-host restore
 - `restore` restores the exact preference state from before the tool first
   changed it, including the distinction between an absent key and an explicit
   Boolean value.
+- `restore --force` is the explicit recovery path that lets the saved original
+  values win over a conflicting live Boolean state.
 
 The selected Xcode comes from `DEVELOPER_DIR` when set and otherwise from
 `xcode-select -p`. The preference domain is shared by every installed Xcode;
@@ -35,25 +37,27 @@ boundary that justifies another product or implementation target.
 ```text
 xcode-simulator-host (executable product)
   -> XcodeSimulatorHost (composition root and all internal owners)
-  -> XcodeSimulatorHostTests
+XcodeSimulatorHostTests
+  -> XcodeSimulatorHost
 ```
 
-Third-party argument parsing and persistence dependencies are intentionally
-absent. The command grammar is closed and small enough for a typed parser, and
-Foundation provides the required process, property-list, and file APIs.
+The CLI surface uses Apple's `swift-argument-parser` 1.8.2. Persistence and system
+integration use Foundation, AppKit, and Darwin directly; no additional runtime
+dependency is required.
 
 ## Owner map
 
 | Responsibility | Owner |
 | --- | --- |
-| Parse commands and options | `CommandParser` |
+| Parse commands and options | `ArgumentParser` command types |
 | Execute fixed system commands | `SystemCommandRunner` |
 | Read and mutate the two Boolean preferences | `DefaultsStore` |
 | Persist the original state and in-flight mutation | `ReceiptStore` |
 | Resolve and validate Xcode 27 | `InstallationInspector` |
 | Resolve and validate a legacy Simulator host | `InstallationInspector` |
+| Validate the legacy Simulator code signature | `CodeSignatureValidator` |
 | Serialize preference transitions and rollback | `HostModeController` |
-| Render output and select an exit category | `CLIApplication` |
+| Render output and select an exit category | `XcodeSimulatorHostApplication` |
 
 The current preference values remain the source of truth for the effective
 mode. The receipt owns only restoration and interruption recovery metadata.
@@ -89,44 +93,68 @@ contains:
 The first successful management attempt creates the receipt before changing a
 preference. Later mode switches never replace the original state.
 
-For every transition, `HostModeController`:
+For every `use` transition, `HostModeController`:
 
 1. acquires an exclusive operation lock;
 2. validates compatibility and confirms all Xcode GUI processes are closed;
 3. reads the current preference state;
 4. saves a pending `before -> target` mutation;
-5. applies both keys and reads them back;
+5. confirms the state still equals `before`, applies both keys, and reads them back;
 6. finalizes the verified state in the receipt.
 
 If applying or verifying either key fails, the controller restores the state
 from immediately before that operation and verifies the rollback. A rollback
 failure is reported as an inconsistent state and the receipt is retained.
 
-On the next invocation, a pending mutation is recovered only when the live
-state equals its `before` or `target` value. Any third value is an external
-conflict and no mutation proceeds.
+On the next `use` or `restore` invocation, a pending mutation is finalized when
+the live state equals its `before` or `target` value. A state matching the
+possible value after writing only the Xcode key is ambiguous: it could be an
+interrupted tool write or an external change made after the journal was saved.
+It is never rolled back automatically. Any other third value is also an
+external conflict, and no mutation proceeds.
+
+`status` takes the same operation lock while reading preferences and the
+receipt, so it cannot combine two different transaction snapshots. It does not
+recover pending state or change a preference or receipt.
+
+`restore` first checks whether a receipt exists. Without one it is a no-op and
+does not read the managed preferences. With one it requires all Xcode GUI
+processes to be closed, recovers an interrupted journal if necessary, restores
+the exact original state, and verifies the read-back. It does not require the
+currently selected Xcode to pass the compatibility gate.
+
+After inspecting a conflict, `restore --force` records the observed Boolean
+state as a new rollback point, writes and verifies the saved original values,
+then deletes the receipt. It still refuses non-Boolean preference values and
+still requires Xcode to be closed.
 
 Opening the legacy Simulator is a separate failure boundary after a successful
 preference transaction. Failure to open it is reported as a partial success;
 the selected mode remains configured and can be restored normally.
 
-`restore` remains available even when the current Xcode is unsupported or
-running. It deletes the receipt only after the original values are read back.
+`restore` remains available when the currently selected Xcode is unsupported.
+Like `use`, it refuses to mutate preferences while Xcode is running. It deletes
+the receipt only after the original values are read back.
 
 ## Compatibility gate
 
-Mutation support is deliberately limited to Xcode 27. A target installation
+`use` support is deliberately limited to Xcode 27. A target installation
 must have:
 
 - bundle identifier `com.apple.dt.Xcode` and major version 27;
 - `Contents/Applications/DeviceHub.app` with identifier
-  `com.apple.dt.Devices`;
-- the expected `IDEiOSSupportCore` binary containing the exact hidden key.
+  `com.apple.dt.Devices`, a launchable bundle executable, and its expected
+  internal implementation executable;
+- the expected `IDEiOSSupportCore` binary containing the exact Xcode key;
+- the Device Hub implementation binary containing the exact auto-start key.
 
 A legacy host must come from Xcode 26 and contain an executable Simulator app
-with bundle identifier `com.apple.iphonesimulator`. Automatic discovery checks
-Xcode applications in `/Applications` and `~/Applications` and chooses the
-highest validated version. `--legacy-xcode` selects an explicit candidate.
+with bundle identifier `com.apple.iphonesimulator`. Before launch, the complete
+Simulator bundle must pass strict static code validation for the requirement
+`identifier "com.apple.iphonesimulator" and anchor apple`. Automatic discovery
+checks Xcode applications in `/Applications` and `~/Applications` and chooses
+the highest validated version. `--legacy-xcode` selects an explicit candidate
+but does not bypass signature validation.
 
 No alternative binary path, preference key, or application is guessed when a
 gate fails. Xcode 28 and later require a new verified compatibility profile.
@@ -146,8 +174,10 @@ The executable follows BSD `sysexits` categories:
 | 75 | Xcode is running or another operation holds the lock |
 | 78 | invalid preference, corrupt receipt, or external conflict |
 
-Errors use stable identifiers on stderr. Successful status and transition
-reports use stdout.
+ArgumentParser owns invocation diagnostics. Operational errors use stable
+identifiers on stderr. Successful transition reports use stdout. `status`
+always writes its report to stdout and exits 78 when a receipt conflicts with
+the live preferences.
 
 ## Non-goals
 

--- a/Documentation/Design.md
+++ b/Documentation/Design.md
@@ -14,8 +14,9 @@ xcode-simulator-host restore [--force]
 
 - `status` is read-only.
 - `use legacy` configures Xcode for a CoreSimulator-only session, prevents an
-  already-running Device Hub from automatically starting a live view, and
-  opens the validated Simulator app from Xcode 26.
+  already-running Device Hub from automatically starting a live view, normally
+  terminates the verified Device Hub, and opens the validated Simulator app
+  from Xcode 26. Xcode itself remains open.
 - `use device-hub` removes both overrides so Xcode 27 uses its default Device
   Hub route.
 - `restore` restores the exact preference state from before the tool first
@@ -57,6 +58,7 @@ dependency is required.
 | Resolve and validate a legacy Simulator host | `InstallationInspector` |
 | Validate the legacy Simulator code signature | `CodeSignatureValidator` |
 | Serialize preference transitions and rollback | `HostModeController` |
+| Observe Xcode, terminate the exact Device Hub, and open Simulator | `WorkspaceClient` |
 | Render output and select an exit category | `XcodeSimulatorHostApplication` |
 
 The current preference values remain the source of truth for the effective
@@ -96,7 +98,7 @@ preference. Later mode switches never replace the original state.
 For every `use` transition, `HostModeController`:
 
 1. acquires an exclusive operation lock;
-2. validates compatibility and confirms all Xcode GUI processes are closed;
+2. validates compatibility while allowing Xcode GUI processes to remain open;
 3. reads the current preference state;
 4. saves a pending `before -> target` mutation;
 5. confirms the state still equals `before`, applies both keys, and reads them back;
@@ -118,23 +120,32 @@ receipt, so it cannot combine two different transaction snapshots. It does not
 recover pending state or change a preference or receipt.
 
 `restore` first checks whether a receipt exists. Without one it is a no-op and
-does not read the managed preferences. With one it requires all Xcode GUI
-processes to be closed, recovers an interrupted journal if necessary, restores
-the exact original state, and verifies the read-back. It does not require the
-currently selected Xcode to pass the compatibility gate.
+does not read the managed preferences. With one it recovers an interrupted
+journal if necessary, restores the exact original state, and verifies the
+read-back while Xcode may remain open. It does not require the currently
+selected Xcode to pass the compatibility gate.
 
 After inspecting a conflict, `restore --force` records the observed Boolean
 state as a new rollback point, writes and verifies the saved original values,
-then deletes the receipt. It still refuses non-Boolean preference values and
-still requires Xcode to be closed.
+then deletes the receipt. It still refuses non-Boolean preference values.
 
-Opening the legacy Simulator is a separate failure boundary after a successful
-preference transaction. Failure to open it is reported as a partial success;
-the selected mode remains configured and can be restored normally.
+Device Hub termination and opening the legacy Simulator are separate failure
+boundaries after a successful preference transaction. `WorkspaceClient` only
+terminates running applications whose resolved bundle URL exactly matches the
+validated Device Hub inside the selected Xcode. It requests normal termination,
+observes `isTerminated` through KVO, and re-enumerates the current
+`NSWorkspace` inventory until no matching process remains within one 10-second
+operation deadline. It never force-terminates Device Hub.
 
-`restore` remains available when the currently selected Xcode is unsupported.
-Like `use`, it refuses to mutate preferences while Xcode is running. It deletes
-the receipt only after the original values are read back.
+Because Device Hub termination suspends, `HostModeController` reacquires the
+operation lock, verifies the committed legacy state, and holds that same lock
+until `NSWorkspace.openApplication` completes. A concurrent switch therefore
+cannot commit between final verification and Simulator launch. Termination and
+launch failures are reported as partial success; the selected mode remains
+configured and can be restored.
+
+`restore` remains available when the currently selected Xcode is unsupported or
+running. It deletes the receipt only after the original values are read back.
 
 ## Compatibility gate
 
@@ -172,7 +183,7 @@ The executable follows BSD `sysexits` categories:
 | 70 | internal invariant failure |
 | 73 | receipt or lock cannot be created |
 | 74 | preference or state I/O failed |
-| 75 | Xcode is running or another operation holds the lock |
+| 75 | another operation holds the lock, or Device Hub does not terminate normally |
 | 78 | invalid preference, corrupt receipt, or external conflict |
 
 ArgumentParser owns invocation diagnostics. Operational errors use stable
@@ -183,7 +194,7 @@ the live preferences.
 ## Non-goals
 
 - Modifying, replacing, re-signing, or deleting Xcode and Device Hub bundles.
-- Killing or automatically restarting Xcode, Device Hub, or Simulator.
+- Force-killing or automatically restarting Xcode, Device Hub, or Simulator.
 - Booting, shutting down, creating, or deleting simulator devices.
 - Making the shared Xcode preference installation-specific.
 - Claiming that the undocumented behavior is supported by Apple.
@@ -199,6 +210,7 @@ domains or launch applications. Coverage includes parsing, compatibility
 gates, tri-state round trips, pending-mutation recovery, idempotence, external
 conflicts, rollback, and restore.
 
-The only live smoke test during development is `status`, which is read-only.
-Changing the real preferences and verifying Xcode's GUI Run behavior is a
-separate, explicitly controlled A/B test.
+The live A/B test keeps one Xcode 27 process running while switching from the
+default Device Hub route to the Xcode 26 Simulator route and back. It verifies
+the host application and launched demo at each step, then restores the exact
+preferences, scheme, destination, app, Device Hub, and simulator-device state.

--- a/Documentation/Design.md
+++ b/Documentation/Design.md
@@ -134,11 +134,13 @@ the complete snapshot under the existing operation lock. Once state exists,
 `status` always uses that existing lock. It does not recover pending state or
 change a preference, receipt, or state artifact.
 
-`restore` first checks whether a receipt exists. Without one it is a no-op and
-does not create state or read the managed preferences. With one it recovers an
-interrupted journal if necessary, restores the exact original state, and
-verifies the read-back while Xcode may remain open. It does not require the
-currently selected Xcode to pass the compatibility gate.
+`restore` first checks the monotonic state directory marker. If it is absent,
+the command is a no-op and does not create state or read the managed
+preferences. If state exists, `restore` acquires the existing operation lock
+before deciding whether a receipt exists. It then recovers an interrupted
+journal if necessary, restores the exact original state, and verifies the
+read-back while Xcode may remain open. It does not require the currently
+selected Xcode to pass the compatibility gate.
 
 After inspecting a conflict, `restore --force` records the observed Boolean
 state as a new rollback point, writes and verifies the saved original values,

--- a/Documentation/Design.md
+++ b/Documentation/Design.md
@@ -1,0 +1,173 @@
+# xcode-simulator-host design
+
+## Consumer contract
+
+`xcode-simulator-host` is a macOS command-line tool for selecting the UI host
+used alongside Xcode 27 simulator runs.
+
+```console
+xcode-simulator-host status
+xcode-simulator-host use legacy [--legacy-xcode /Applications/Xcode.app]
+xcode-simulator-host use device-hub
+xcode-simulator-host restore
+```
+
+- `status` is read-only.
+- `use legacy` configures Xcode for a CoreSimulator-only session, prevents an
+  already-running Device Hub from automatically starting a live view, and
+  opens the validated Simulator app from Xcode 26.
+- `use device-hub` removes both overrides so Xcode 27 uses its default Device
+  Hub route.
+- `restore` restores the exact preference state from before the tool first
+  changed it, including the distinction between an absent key and an explicit
+  Boolean value.
+
+The selected Xcode comes from `DEVELOPER_DIR` when set and otherwise from
+`xcode-select -p`. The preference domain is shared by every installed Xcode;
+selecting an Xcode only chooses the installation to validate.
+
+## Package topology
+
+The package has one executable product, one executable target, and one test
+target. There is no library consumer and no independent release or dependency
+boundary that justifies another product or implementation target.
+
+```text
+xcode-simulator-host (executable product)
+  -> XcodeSimulatorHost (composition root and all internal owners)
+  -> XcodeSimulatorHostTests
+```
+
+Third-party argument parsing and persistence dependencies are intentionally
+absent. The command grammar is closed and small enough for a typed parser, and
+Foundation provides the required process, property-list, and file APIs.
+
+## Owner map
+
+| Responsibility | Owner |
+| --- | --- |
+| Parse commands and options | `CommandParser` |
+| Execute fixed system commands | `SystemCommandRunner` |
+| Read and mutate the two Boolean preferences | `DefaultsStore` |
+| Persist the original state and in-flight mutation | `ReceiptStore` |
+| Resolve and validate Xcode 27 | `InstallationInspector` |
+| Resolve and validate a legacy Simulator host | `InstallationInspector` |
+| Serialize preference transitions and rollback | `HostModeController` |
+| Render output and select an exit category | `CLIApplication` |
+
+The current preference values remain the source of truth for the effective
+mode. The receipt owns only restoration and interruption recovery metadata.
+
+## Managed preferences
+
+```text
+domain: com.apple.dt.Xcode
+key:    DVTiPhoneSimulatorAlwaysLaunchInCoreSimulatorSession
+
+domain: com.apple.dt.Devices
+key:    disableAutoStartLiveDeviceView
+```
+
+Each value is modeled as one of `absent`, `false`, or `true`. Any other stored
+type is a configuration error and is never guessed or overwritten.
+
+The `defaults` command is the live adapter. Direct `CFPreferences` access from
+this unsandboxed tool cannot observe the Device Hub container preference, while
+`defaults` resolves that domain to its application container.
+
+## Transition transaction
+
+The receipt is stored under the user's Application Support directory. It
+contains:
+
+- schema and tool identifiers;
+- the original two-key state;
+- the state the tool most recently verified;
+- an optional pending mutation with `before` and `target` states;
+- the Xcode version and build validated at capture time.
+
+The first successful management attempt creates the receipt before changing a
+preference. Later mode switches never replace the original state.
+
+For every transition, `HostModeController`:
+
+1. acquires an exclusive operation lock;
+2. validates compatibility and confirms all Xcode GUI processes are closed;
+3. reads the current preference state;
+4. saves a pending `before -> target` mutation;
+5. applies both keys and reads them back;
+6. finalizes the verified state in the receipt.
+
+If applying or verifying either key fails, the controller restores the state
+from immediately before that operation and verifies the rollback. A rollback
+failure is reported as an inconsistent state and the receipt is retained.
+
+On the next invocation, a pending mutation is recovered only when the live
+state equals its `before` or `target` value. Any third value is an external
+conflict and no mutation proceeds.
+
+Opening the legacy Simulator is a separate failure boundary after a successful
+preference transaction. Failure to open it is reported as a partial success;
+the selected mode remains configured and can be restored normally.
+
+`restore` remains available even when the current Xcode is unsupported or
+running. It deletes the receipt only after the original values are read back.
+
+## Compatibility gate
+
+Mutation support is deliberately limited to Xcode 27. A target installation
+must have:
+
+- bundle identifier `com.apple.dt.Xcode` and major version 27;
+- `Contents/Applications/DeviceHub.app` with identifier
+  `com.apple.dt.Devices`;
+- the expected `IDEiOSSupportCore` binary containing the exact hidden key.
+
+A legacy host must come from Xcode 26 and contain an executable Simulator app
+with bundle identifier `com.apple.iphonesimulator`. Automatic discovery checks
+Xcode applications in `/Applications` and `~/Applications` and chooses the
+highest validated version. `--legacy-xcode` selects an explicit candidate.
+
+No alternative binary path, preference key, or application is guessed when a
+gate fails. Xcode 28 and later require a new verified compatibility profile.
+
+## Failure semantics
+
+The executable follows BSD `sysexits` categories:
+
+| Code | Meaning |
+| ---: | --- |
+| 0 | success or documented no-op |
+| 64 | invalid invocation |
+| 69 | unavailable or unsupported Xcode/Simulator |
+| 70 | internal invariant failure |
+| 73 | receipt or lock cannot be created |
+| 74 | preference or state I/O failed |
+| 75 | Xcode is running or another operation holds the lock |
+| 78 | invalid preference, corrupt receipt, or external conflict |
+
+Errors use stable identifiers on stderr. Successful status and transition
+reports use stdout.
+
+## Non-goals
+
+- Modifying, replacing, re-signing, or deleting Xcode and Device Hub bundles.
+- Killing or automatically restarting Xcode, Device Hub, or Simulator.
+- Booting, shutting down, creating, or deleting simulator devices.
+- Making the shared Xcode preference installation-specific.
+- Claiming that the undocumented behavior is supported by Apple.
+- Guessing support for Xcode 28 or a different legacy Simulator generation.
+- Providing a public Swift library API, JSON output, or shell completion in the
+  initial release.
+
+## Validation
+
+Unit tests use a scripted command runner, fake Xcode bundles, and isolated
+temporary receipt directories. They never write the real Xcode or Device Hub
+domains or launch applications. Coverage includes parsing, compatibility
+gates, tri-state round trips, pending-mutation recovery, idempotence, external
+conflicts, rollback, and restore.
+
+The only live smoke test during development is `status`, which is read-only.
+Changing the real preferences and verifying Xcode's GUI Run behavior is a
+separate, explicitly controlled A/B test.

--- a/Documentation/Design.md
+++ b/Documentation/Design.md
@@ -130,19 +130,21 @@ state as a new rollback point, writes and verifies the saved original values,
 then deletes the receipt. It still refuses non-Boolean preference values.
 
 Device Hub termination and opening the legacy Simulator are separate failure
-boundaries after a successful preference transaction. `WorkspaceClient` only
-terminates running applications whose resolved bundle URL exactly matches the
-validated Device Hub inside the selected Xcode. It requests normal termination,
-observes `isTerminated` through KVO, and re-enumerates the current
-`NSWorkspace` inventory until no matching process remains within one 10-second
-operation deadline. It never force-terminates Device Hub.
+boundaries after a successful preference transaction, but remain inside the
+same exclusive operation lock. `WorkspaceClient` only terminates running
+applications whose resolved bundle URL exactly matches the validated Device Hub
+inside the selected Xcode. It requests normal termination, observes
+`isTerminated` through KVO, and re-enumerates the current `NSWorkspace`
+inventory until no matching process remains within one 10-second operation
+deadline. It never force-terminates Device Hub.
 
-Because Device Hub termination suspends, `HostModeController` reacquires the
-operation lock, verifies the committed legacy state, and holds that same lock
-until `NSWorkspace.openApplication` completes. A concurrent switch therefore
-cannot commit between final verification and Simulator launch. Termination and
-launch failures are reported as partial success; the selected mode remains
-configured and can be restored.
+`HostModeController` holds the operation lock from compatibility validation
+through preference commit, Device Hub termination, final legacy-state
+verification, and `NSWorkspace.openApplication` completion. A concurrent
+switch or restore therefore cannot commit while an older legacy operation is
+still applying process lifecycle side effects. Termination and launch failures
+are reported as partial success; the selected mode remains configured and can
+be restored.
 
 `restore` remains available when the currently selected Xcode is unsupported or
 running. It deletes the receipt only after the original values are read back.

--- a/Documentation/Design.md
+++ b/Documentation/Design.md
@@ -171,6 +171,23 @@ bypass signature or generation validation.
 No alternative binary path, preference key, or application is guessed when a
 gate fails. Xcode 28 and later require a new verified compatibility profile.
 
+## Distribution
+
+GitHub Releases distribute one ad-hoc-signed arm64 archive containing
+`bin/xcode-simulator-host`. Each release also contains `SHA256SUMS.txt` and a
+version-pinned `install.sh`. The installer downloads the archive and checksum
+from the same tag, verifies the archive before extraction, and installs to
+`~/.local/bin` by default. `--prefix` and `--bindir` select another destination.
+It prints PATH guidance but never edits a shell profile.
+
+The build script rejects a release tag whose semantic version does not match
+the binary's `--version`. The packaging verifier checks the exact asset set,
+checksums, rendered installer, and archive entries. `release.yml` runs package
+tests, builds and verifies the assets on an arm64 macOS 26 runner, transfers the
+archive digest across jobs, and creates or repairs a draft release. Publishing
+the draft remains a manual action. A version with a prerelease suffix is marked
+as a GitHub prerelease and explicitly excluded from `releases/latest`.
+
 ## Failure semantics
 
 The executable follows BSD `sysexits` categories:

--- a/Documentation/Design.md
+++ b/Documentation/Design.md
@@ -150,11 +150,12 @@ must have:
 
 A legacy host must come from Xcode 26 and contain an executable Simulator app
 with bundle identifier `com.apple.iphonesimulator`. Before launch, the complete
-Simulator bundle must pass strict static code validation for the requirement
-`identifier "com.apple.iphonesimulator" and anchor apple`. Automatic discovery
-checks Xcode applications in `/Applications` and `~/Applications` and chooses
-the highest validated version. `--legacy-xcode` selects an explicit candidate
-but does not bypass signature validation.
+outer Xcode and nested Simulator bundles must pass strict static code validation
+for their respective identifiers and `anchor apple`. The signed Simulator
+`DTXcode` value must also identify Xcode major 26. Automatic discovery checks
+Xcode applications in `/Applications` and chooses the highest validated
+version. `--legacy-xcode` selects an explicit candidate elsewhere but does not
+bypass signature or generation validation.
 
 No alternative binary path, preference key, or application is guessed when a
 gate fails. Xcode 28 and later require a new verified compatibility profile.

--- a/Documentation/Design.md
+++ b/Documentation/Design.md
@@ -115,15 +115,19 @@ interrupted tool write or an external change made after the journal was saved.
 It is never rolled back automatically. Any other third value is also an
 external conflict, and no mutation proceeds.
 
-`status` takes the same operation lock while reading preferences and the
-receipt, so it cannot combine two different transaction snapshots. It does not
-recover pending state or change a preference or receipt.
+`status` does not create the state directory or operation lock. Before the
+first mutation it takes an optimistic snapshot and confirms that the state
+directory stayed absent. Creating that directory is the first, monotonic step
+of every mutating operation, so if it appears during the read, `status` retries
+the complete snapshot under the existing operation lock. Once state exists,
+`status` always uses that existing lock. It does not recover pending state or
+change a preference, receipt, or state artifact.
 
 `restore` first checks whether a receipt exists. Without one it is a no-op and
-does not read the managed preferences. With one it recovers an interrupted
-journal if necessary, restores the exact original state, and verifies the
-read-back while Xcode may remain open. It does not require the currently
-selected Xcode to pass the compatibility gate.
+does not create state or read the managed preferences. With one it recovers an
+interrupted journal if necessary, restores the exact original state, and
+verifies the read-back while Xcode may remain open. It does not require the
+currently selected Xcode to pass the compatibility gate.
 
 After inspecting a conflict, `restore --force` records the observed Boolean
 state as a new rollback point, writes and verifies the saved original values,

--- a/Documentation/Design.md
+++ b/Documentation/Design.md
@@ -183,10 +183,11 @@ It prints PATH guidance but never edits a shell profile.
 The build script rejects a release tag whose semantic version does not match
 the binary's `--version`. The packaging verifier checks the exact asset set,
 checksums, rendered installer, and archive entries. `release.yml` runs package
-tests, builds and verifies the assets on an arm64 macOS 26 runner, transfers the
-archive digest across jobs, and creates or repairs a draft release. Publishing
-the draft remains a manual action. A version with a prerelease suffix is marked
-as a GitHub prerelease and explicitly excluded from `releases/latest`.
+tests, builds and verifies the assets on GitHub's arm64 Xcode 27 runner,
+transfers the archive digest across jobs, and creates or repairs a draft
+release. Publishing the draft remains a manual action. A version with a
+prerelease suffix is marked as a GitHub prerelease and explicitly excluded from
+`releases/latest`.
 
 ## Failure semantics
 

--- a/Documentation/Design.md
+++ b/Documentation/Design.md
@@ -101,12 +101,23 @@ For every `use` transition, `HostModeController`:
 2. validates compatibility while allowing Xcode GUI processes to remain open;
 3. reads the current preference state;
 4. saves a pending `before -> target` mutation;
-5. confirms the state still equals `before`, applies both keys, and reads them back;
+5. brackets every individual preference write with full-state verification;
 6. finalizes the verified state in the receipt.
 
 If applying or verifying either key fails, the controller restores the state
-from immediately before that operation and verifies the rollback. A rollback
-failure is reported as an inconsistent state and the receipt is retained.
+from immediately before that operation using the same guarded step sequence.
+If a pre-write or post-write check detects a different state, no automatic
+rollback runs over that state; the pending receipt is retained and the
+forward transition is reported as a conflict. A deviation detected during
+rollback, or a different rollback failure, is reported as an inconsistent
+state and the receipt is retained.
+
+The `defaults` command does not provide a conditional compare-and-swap. The
+operation lock serializes this tool's processes, while full-state reads
+immediately before and after each write detect cooperating or slower external
+changes. An external write in the narrow interval between a check and the
+managed write can be indistinguishable if the managed write replaces it with
+the intended value.
 
 On the next `use` or `restore` invocation, a pending mutation is finalized when
 the live state equals its `before` or `target` value. A state matching the

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kazuki Nakashima
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "88b1b2b2ac5a0e632133afabfef05ac3e11d778edc70d572dcafafe4f1a190b5",
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,32 +1,37 @@
 // swift-tools-version: 6.4
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "xcode-simulator-host",
+    platforms: [
+        .macOS("26.4"),
+    ],
     products: [
-        // Products define the executables and libraries a package produces, making them visible to other packages.
-        .library(
+        .executable(
             name: "xcode-simulator-host",
-            targets: ["xcode_simulator_host"]
+            targets: ["XcodeSimulatorHost"]
+        ),
+    ],
+    dependencies: [
+        .package(
+            url: "https://github.com/apple/swift-argument-parser.git",
+            from: "1.8.2"
         ),
     ],
     targets: [
-        // Targets are the basic building blocks of a package, defining a module or a test suite.
-        // Targets can depend on other targets in this package and products from dependencies.
-        .target(
-            name: "xcode_simulator_host",
-            swiftSettings: [
-                .enableUpcomingFeature("ApproachableConcurrency"),
-            ],
+        .executableTarget(
+            name: "XcodeSimulatorHost",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]
         ),
         .testTarget(
-            name: "xcode_simulator_hostTests",
-            dependencies: ["xcode_simulator_host"],
-            swiftSettings: [
-                .enableUpcomingFeature("ApproachableConcurrency"),
-            ],
+            name: "XcodeSimulatorHostTests",
+            dependencies: [
+                "XcodeSimulatorHost",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,0 +1,146 @@
+# xcode-simulator-host
+
+Xcode 27 の iOS Simulator 実行経路を、Device Hub と Xcode 26 の従来型
+Simulator の間で切り替える macOS コマンドです。
+
+Apple が公開していない Xcode 27 の設定を利用する実験的なツールです。対応範囲を
+推測せず、選択中の Xcode、Device Hub、設定キーを検証できた場合だけ変更します。
+
+## Quick Start
+
+Xcode 27 と Xcode 26 を終了してから、リポジトリ内で次を実行します。
+
+```bash
+swift run -c release xcode-simulator-host status
+swift run -c release xcode-simulator-host use legacy
+```
+
+`use legacy` は設定変更後に、検証済みの Xcode 26 内の Simulator を開きます。
+その後 Xcode 27 を開き、通常どおり GUI から Build & Run します。
+
+Device Hub 経路へ切り替える場合も、先にすべての Xcode を終了します。
+
+```bash
+swift run -c release xcode-simulator-host use device-hub
+```
+
+このツールを初めて実行する前の設定へ正確に戻すには、`restore` を使います。
+
+```bash
+swift run -c release xcode-simulator-host restore
+```
+
+`use device-hub` は Device Hub 用の標準状態（両方の上書き設定が存在しない状態）を
+選びます。`restore` は、設定キーが存在しなかったか、明示的な `false` / `true`
+だったかも含め、最初に保存した状態を復元します。
+
+## Requirements
+
+- macOS 26.4 以降（Xcode 27 の `LSMinimumSystemVersion` に合わせています）
+- Swift 6.4 を含む Xcode 27
+- 従来型 Simulator 用の Xcode 26（`use legacy` のみ）
+
+対象の Xcode 27 は `DEVELOPER_DIR`、未指定なら `xcode-select -p` から解決します。
+たとえば `/Applications/Xcode_27.app` を一回だけ指定する場合は次のとおりです。
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode_27.app/Contents/Developer \
+  swift run -c release xcode-simulator-host status
+```
+
+従来型 Simulator は `/Applications` と `~/Applications` にある検証済み Xcode 26
+のうち、最も新しいものを選びます。明示する場合は絶対パスを渡します。
+
+```bash
+swift run -c release xcode-simulator-host use legacy \
+  --legacy-xcode /Applications/Xcode.app
+```
+
+`sudo` は使わないでください。このコマンドは現在のユーザーの Xcode 設定を管理します。
+
+## Commands
+
+```console
+xcode-simulator-host status
+xcode-simulator-host use legacy [--legacy-xcode /absolute/path/to/Xcode.app]
+xcode-simulator-host use device-hub
+xcode-simulator-host restore [--force]
+```
+
+- `status`: 選択中の Xcode、2つの設定値、Xcode 26 Simulator、復元情報、実行中の
+  Xcode を表示します。実設定は変更しません。
+- `use legacy`: Device Hub を経由しない CoreSimulator セッションを選び、Xcode 26
+  の Simulator を開きます。
+- `use device-hub`: 2つの上書き設定を削除し、Xcode 27 の標準 Device Hub 経路を
+  選びます。
+- `restore`: 最初の変更前に保存した2つの設定を復元します。live設定とreceiptが
+  conflictしている場合は上書きしません。
+- `restore --force`: conflictを確認したユーザーの明示操作として、保存済みの元設定を
+  現在のBoolean値より優先します。
+
+`use` は、Xcode が1つでも実行中なら設定を変更しません。Simulator の起動だけに
+失敗した場合は、設定変更済みであることをエラーに明記します。その状態も `restore`
+で復元できます。
+
+復元対象がある `restore` も、Xcode が実行中なら停止します。Xcode の設定キャッシュに
+よる再保存と競合させないためです。すべての Xcode を終了して再実行してください。
+
+## Build
+
+依存には Apple の
+[swift-argument-parser](https://github.com/apple/swift-argument-parser) 1.8.2 を使います。
+
+```bash
+swift build -c release
+.build/release/xcode-simulator-host --help
+```
+
+任意で、生成した実行ファイルを PATH 上のディレクトリへコピーできます。
+
+```bash
+install -d ~/.local/bin
+install -m 755 .build/release/xcode-simulator-host ~/.local/bin/xcode-simulator-host
+```
+
+## Safety and recovery
+
+初回変更前の値と進行中の変更は、次に保存します。
+
+```text
+~/Library/Application Support/xcode-simulator-host/state.plist
+```
+
+設定変更は排他ロック下で実行し、各値を読み戻してから完了とします。途中で失敗した
+場合は直前の状態へロールバックします。外部から設定が変わって保存内容と一致しない
+場合は conflict として停止し、推測で上書きしません。
+
+receiptに記録した2設定の書き込み途中と同じ値が見つかっても、それがこのツールの
+中断結果か外部変更かは証明できません。この場合も自動復旧せず、`status`は終了コード
+`78`で曖昧な状態を表示します。receiptと現在値を確認し、保存済みの元設定を優先すると
+判断した場合だけ、Xcodeを終了して `restore --force` を実行してください。
+
+終了コードはBSD `sysexits`に沿います。主な値は `0`（成功または仕様上のno-op）、
+`64`（引数エラー）、`69`（対応するXcode/Simulatorなし）、`74`（I/O失敗）、
+`75`（Xcode実行中またはlock競合）、`78`（設定不整合・receipt conflict）です。
+`status` はconflictの内容をstdoutへ表示し、`78`で終了します。
+
+アンインストールや状態ファイルの削除より先に `restore` を実行してください。
+
+Xcode の設定ドメイン `com.apple.dt.Xcode` はインストールごとではなく共有です。
+このツールで選択した Xcode 27 は互換性確認の対象であり、設定の適用先をその
+Xcode だけに限定するものではありません。
+
+自動探索または `--legacy-xcode` で指定した Simulator は、bundle情報と実行ファイルに
+加えて、identifier `com.apple.iphonesimulator` と Apple anchor を満たすcode signatureを
+検証してから開きます。
+
+設計、管理する設定、トランザクション、失敗意味論の詳細は
+[Documentation/Design.md](Documentation/Design.md) を参照してください。
+
+## Development
+
+テストは一時ディレクトリと偽の Xcode bundle を使い、実際の設定やアプリを変更しません。
+
+```bash
+swift test
+```

--- a/README.md
+++ b/README.md
@@ -6,13 +6,36 @@ Simulator の間で切り替える macOS コマンドです。
 Apple が公開していない Xcode 27 の設定を利用する実験的なツールです。対応範囲を
 推測せず、選択中の Xcode、Device Hub、設定キーを検証できた場合だけ変更します。
 
-## Quick Start
-
-Xcode 27 を開いたまま、リポジトリ内で次を実行できます。
+## Install
 
 ```bash
-swift run -c release xcode-simulator-host status
-swift run -c release xcode-simulator-host use legacy
+curl -fsSL https://github.com/lynnswap/xcode-simulator-host/releases/latest/download/install.sh | sh
+```
+
+<details>
+<summary>Other install options</summary>
+
+インストール先を指定します。
+
+```bash
+curl -fsSL https://github.com/lynnswap/xcode-simulator-host/releases/latest/download/install.sh | sh -s -- --bindir "$HOME/bin"
+```
+
+versionを固定します。
+
+```bash
+curl -fsSL https://github.com/lynnswap/xcode-simulator-host/releases/download/v0.1.0/install.sh | sh
+```
+
+</details>
+
+## Quick Start
+
+Xcode 27を開いたまま実行できます。
+
+```bash
+xcode-simulator-host status
+xcode-simulator-host use legacy
 ```
 
 `use legacy` は設定変更後に、選択中のXcode 27に含まれるDevice Hubへ通常終了を
@@ -22,13 +45,13 @@ Build & Runします。
 Device Hub経路へ戻す場合もXcodeを終了する必要はありません。
 
 ```bash
-swift run -c release xcode-simulator-host use device-hub
+xcode-simulator-host use device-hub
 ```
 
 このツールを初めて実行する前の設定へ正確に戻すには、`restore` を使います。
 
 ```bash
-swift run -c release xcode-simulator-host restore
+xcode-simulator-host restore
 ```
 
 `use device-hub` は Device Hub 用の標準状態（両方の上書き設定が存在しない状態）を
@@ -38,7 +61,8 @@ swift run -c release xcode-simulator-host restore
 ## Requirements
 
 - macOS 26.4 以降（Xcode 27 の `LSMinimumSystemVersion` に合わせています）
-- Swift 6.4 を含む Xcode 27
+- GitHub ReleasesのbinaryはApple Silicon
+- Xcode 27（source buildにはSwift 6.4が必要）
 - 従来型 Simulator 用の Xcode 26（`use legacy` のみ）
 
 対象の Xcode 27 は `DEVELOPER_DIR`、未指定なら `xcode-select -p` から解決します。
@@ -46,14 +70,14 @@ swift run -c release xcode-simulator-host restore
 
 ```bash
 DEVELOPER_DIR=/Applications/Xcode_27.app/Contents/Developer \
-  swift run -c release xcode-simulator-host status
+  xcode-simulator-host status
 ```
 
 従来型 Simulator は `/Applications` にある検証済み Xcode 26 のうち、最も新しい
 ものを選びます。別の場所にあるXcodeを明示する場合は絶対パスを渡します。
 
 ```bash
-swift run -c release xcode-simulator-host use legacy \
+xcode-simulator-host use legacy \
   --legacy-xcode /Applications/Xcode.app
 ```
 
@@ -86,7 +110,7 @@ Simulatorを開きます。最終確認からopen完了までは同じoperation 
 起動だけに失敗した場合は、設定変更済みであることをpartial-successエラーに明記します。
 その状態も `restore` で復元できます。
 
-## Build
+## Build from Source
 
 依存には Apple の
 [swift-argument-parser](https://github.com/apple/swift-argument-parser) 1.8.2 を使います。
@@ -153,6 +177,26 @@ Simulatorの署名済み `DTXcode` もmajor 26である場合だけ開きます�
 ```bash
 swift test
 ```
+
+release assetをローカルで作成・検証します。
+
+```bash
+scripts/build-release.sh --version v0.1.0
+scripts/package-release.sh --version v0.1.0
+scripts/verify-release-assets.sh \
+  --version v0.1.0 \
+  --repo lynnswap/xcode-simulator-host
+```
+
+GitHubではdefault branchの最新commitからworkflowをdispatchします。
+
+```bash
+gh workflow run release.yml --ref main -f version=v0.1.0
+```
+
+workflowはtagとassetを持つdraft releaseを作成します。release notesを確認してから
+GitHub上で手動publishします。suffix付きversionはprereleaseとして作成され、
+`releases/latest`のinstall経路には入りません。
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,83 @@
 # xcode-simulator-host
 
-Xcode 27 の iOS Simulator 実行経路を、Device Hub と Xcode 26 の従来型
-Simulator の間で切り替える macOS コマンドです。
+Switch Xcode 27 iOS Simulator runs between Device Hub and the classic Simulator
+app from Xcode 26 while Xcode remains open.
 
-Apple が公開していない Xcode 27 の設定を利用する実験的なツールです。対応範囲を
-推測せず、選択中の Xcode、Device Hub、設定キーを検証できた場合だけ変更します。
+This is an experimental tool built around undocumented Xcode preferences. It
+checks the selected Xcode 27 installation, Device Hub, and managed preference
+keys for the expected compatibility markers before `use` changes anything.
+`use legacy` additionally requires an Apple-signed Xcode 26 and Simulator.
 
-## Install
+Requires macOS 26.4 or later and Xcode 27. Prebuilt releases are for Apple
+Silicon. The legacy route also requires an installed Xcode 26; source builds
+require Swift 6.4.
+
+## Quick Start
 
 ```bash
 curl -fsSL https://github.com/lynnswap/xcode-simulator-host/releases/latest/download/install.sh | sh
 ```
 
-<details>
-<summary>Other install options</summary>
+Inspect the current configuration, then switch to the Xcode 26 Simulator:
 
-インストール先を指定します。
+```bash
+xcode-simulator-host status
+xcode-simulator-host use legacy
+```
+
+Leave Xcode 27 open. After the command opens Simulator, use **Build & Run** in
+Xcode as usual.
+
+Switch back to Xcode 27's Device Hub route:
+
+```bash
+xcode-simulator-host use device-hub
+```
+
+Restore the exact preference state saved before the tool's first change:
+
+```bash
+xcode-simulator-host restore
+```
+
+`use device-hub` selects Xcode 27's default route by removing both overrides.
+`restore` instead preserves whether each original preference was absent,
+explicitly `false`, or explicitly `true`.
+
+## Selecting Xcode Installations
+
+The Xcode 27 installation comes from `DEVELOPER_DIR`, or from `xcode-select -p`
+when `DEVELOPER_DIR` is unset:
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode_27.app/Contents/Developer \
+  xcode-simulator-host status
+```
+
+`use legacy` selects the newest validated Xcode 26 in `/Applications`. Pass an
+absolute path when the installation is elsewhere:
+
+```bash
+xcode-simulator-host use legacy \
+  --legacy-xcode /Applications/Xcode_26.app
+```
+
+The managed Xcode preference is shared by all installed Xcode versions. The
+selected Xcode 27 determines which installation is validated, not a separate
+preference domain.
+
+## Install Options
+
+<details>
+<summary>Custom directory or pinned version</summary>
+
+Install into a custom directory:
 
 ```bash
 curl -fsSL https://github.com/lynnswap/xcode-simulator-host/releases/latest/download/install.sh | sh -s -- --bindir "$HOME/bin"
 ```
 
-versionを固定します。
+Install a specific version:
 
 ```bash
 curl -fsSL https://github.com/lynnswap/xcode-simulator-host/releases/download/v0.1.0/install.sh | sh
@@ -29,175 +85,52 @@ curl -fsSL https://github.com/lynnswap/xcode-simulator-host/releases/download/v0
 
 </details>
 
-## Quick Start
+The installer verifies the release checksum and never edits shell profiles.
+Use `xcode-simulator-host --help` for the complete command and option list.
 
-Xcode 27を開いたまま実行できます。
+## Safety and Recovery
 
-```bash
-xcode-simulator-host status
-xcode-simulator-host use legacy
-```
+`use` validates the selected Xcode before changing preferences, serializes
+transitions, verifies every write, and rolls back a failed transition. `restore`
+remains available without that compatibility check so the saved values can be
+recovered. The tool only requests normal termination of the exact Device Hub
+inside the selected Xcode; it never force-quits Xcode or Device Hub.
 
-`use legacy` は設定変更後に、選択中のXcode 27に含まれるDevice Hubへ通常終了を
-依頼し、検証済みのXcode 26内のSimulatorを開きます。そのままXcode 27のGUIから
-Build & Runします。
-
-Device Hub経路へ戻す場合もXcodeを終了する必要はありません。
-
-```bash
-xcode-simulator-host use device-hub
-```
-
-このツールを初めて実行する前の設定へ正確に戻すには、`restore` を使います。
-
-```bash
-xcode-simulator-host restore
-```
-
-`use device-hub` は Device Hub 用の標準状態（両方の上書き設定が存在しない状態）を
-選びます。`restore` は、設定キーが存在しなかったか、明示的な `false` / `true`
-だったかも含め、最初に保存した状態を復元します。
-
-## Requirements
-
-- macOS 26.4 以降（Xcode 27 の `LSMinimumSystemVersion` に合わせています）
-- GitHub ReleasesのbinaryはApple Silicon
-- Xcode 27（source buildにはSwift 6.4が必要）
-- 従来型 Simulator 用の Xcode 26（`use legacy` のみ）
-
-対象の Xcode 27 は `DEVELOPER_DIR`、未指定なら `xcode-select -p` から解決します。
-たとえば `/Applications/Xcode_27.app` を一回だけ指定する場合は次のとおりです。
-
-```bash
-DEVELOPER_DIR=/Applications/Xcode_27.app/Contents/Developer \
-  xcode-simulator-host status
-```
-
-従来型 Simulator は `/Applications` にある検証済み Xcode 26 のうち、最も新しい
-ものを選びます。別の場所にあるXcodeを明示する場合は絶対パスを渡します。
-
-```bash
-xcode-simulator-host use legacy \
-  --legacy-xcode /Applications/Xcode.app
-```
-
-`sudo` は使わないでください。このコマンドは現在のユーザーの Xcode 設定を管理します。
-
-## Commands
-
-```console
-xcode-simulator-host status
-xcode-simulator-host use legacy [--legacy-xcode /absolute/path/to/Xcode.app]
-xcode-simulator-host use device-hub
-xcode-simulator-host restore [--force]
-```
-
-- `status`: 選択中の Xcode、2つの設定値、Xcode 26 Simulator、復元情報、実行中の
-  Xcode を表示します。実設定は変更しません。
-- `use legacy`: Device Hub を経由しない CoreSimulator セッションを選び、Xcode 26
-  の Simulator を開きます。実行中のDevice Hubは正常終了させます。
-- `use device-hub`: 2つの上書き設定を削除し、Xcode 27 の標準 Device Hub 経路を
-  選びます。
-- `restore`: 最初の変更前に保存した2つの設定を復元します。live設定とreceiptが
-  conflictしている場合は上書きしません。
-- `restore --force`: conflictを確認したユーザーの明示操作として、保存済みの元設定を
-  現在のBoolean値より優先します。
-
-`use` と `restore` はXcodeの起動中にも設定を切り替えます。`use legacy` では設定の
-commit後にDevice Hubの終了完了を待ち、設定がまだlegacyであることを再確認してから
-Simulatorを開きます。最終確認からopen完了までは同じoperation lockを保持するため、
-並行する別の切り替えが間へ入ることはありません。Device Hubの終了またはSimulatorの
-起動だけに失敗した場合は、設定変更済みであることをpartial-successエラーに明記します。
-その状態も `restore` で復元できます。
-
-## Build from Source
-
-依存には Apple の
-[swift-argument-parser](https://github.com/apple/swift-argument-parser) 1.8.2 を使います。
-
-```bash
-swift build -c release
-.build/release/xcode-simulator-host --help
-```
-
-任意で、生成した実行ファイルを PATH 上のディレクトリへコピーできます。
-
-```bash
-install -d ~/.local/bin
-install -m 755 .build/release/xcode-simulator-host ~/.local/bin/xcode-simulator-host
-```
-
-## Safety and recovery
-
-初回変更前の値と進行中の変更は、次に保存します。
+The original preference state and any in-progress transition are stored at:
 
 ```text
 ~/Library/Application Support/xcode-simulator-host/state.plist
 ```
 
-設定変更は排他ロック下で実行し、各値を読み戻してから完了とします。途中で失敗した
-場合は直前の状態へロールバックします。外部から設定が変わって保存内容と一致しない
-場合は conflict として停止し、推測で上書きしません。
+If the tool detects that another process changed a managed preference, it stops
+rather than guessing which value should win. Inspect `status` before using
+`restore --force`, which explicitly gives the saved original state precedence
+over conflicting Boolean values. If Device Hub termination or Simulator launch
+fails after the preference transaction commits, the command reports partial
+success; check `status` before retrying or restoring.
 
-receiptに記録した2設定の書き込み途中と同じ値が見つかっても、それがこのツールの
-中断結果か外部変更かは証明できません。この場合も自動復旧せず、`status`は終了コード
-`78`で曖昧な状態を表示します。receiptと現在値を確認し、保存済みの元設定を優先すると
-判断した場合だけ `restore --force` を実行してください。Xcodeは開いたままで構いません。
+Do not run mutation commands with `sudo`; preferences and recovery state are
+per-user. Run `restore` before uninstalling the command or deleting its state
+file.
 
-終了コードはBSD `sysexits`に沿います。主な値は `0`（成功または仕様上のno-op）、
-`64`（引数エラー）、`69`（対応するXcode/Simulatorなし）、`74`（I/O失敗）、
-`75`（lock競合、またはDevice Hubの正常終了失敗）、`78`（設定不整合・receipt
-conflict）です。
-`status` はconflictの内容をstdoutへ表示し、`78`で終了します。
+See [Design and safety contract](Documentation/Design.md) for compatibility
+checks, transaction ownership, partial-success behavior, and exit codes.
 
-アンインストールや状態ファイルの削除より先に `restore` を実行してください。
+## Build from Source
 
-Xcode の設定ドメイン `com.apple.dt.Xcode` はインストールごとではなく共有です。
-このツールで選択した Xcode 27 は互換性確認の対象であり、設定の適用先をその
-Xcode だけに限定するものではありません。
+```bash
+git clone https://github.com/lynnswap/xcode-simulator-host.git
+cd xcode-simulator-host
+swift build -c release
+.build/release/xcode-simulator-host --help
+```
 
-自動探索または `--legacy-xcode` で指定したXcodeとSimulatorは、bundle情報と実行
-ファイルに加えてApple code signatureを検証します。外側はidentifier
-`com.apple.dt.Xcode`、内側は `com.apple.iphonesimulator` とApple anchorを満たし、
-Simulatorの署名済み `DTXcode` もmajor 26である場合だけ開きます。
-
-終了対象のDevice Hubも、選択中Xcode内の検証済みbundle URLと完全一致するものに
-限定します。同じbundle identifierを名乗る別pathのprocessは終了しません。終了要求後は
-`NSRunningApplication.isTerminated` のKVOで完了を確認し、`NSWorkspace`のfull inventoryを
-読み直します。再起動したinstanceを含めて最大10秒間、実行中の対象が0になるまで収束
-させます。強制終了は行いません。
-
-設計、管理する設定、トランザクション、失敗意味論の詳細は
-[Documentation/Design.md](Documentation/Design.md) を参照してください。
-
-## Development
-
-テストは一時ディレクトリと偽の Xcode bundle を使い、実際の設定やアプリを変更しません。
+Run the isolated test suite with:
 
 ```bash
 swift test
 ```
 
-release assetをローカルで作成・検証します。
-
-```bash
-scripts/build-release.sh --version v0.1.0
-scripts/package-release.sh --version v0.1.0
-scripts/verify-release-assets.sh \
-  --version v0.1.0 \
-  --repo lynnswap/xcode-simulator-host
-```
-
-GitHubではdefault branchの最新commitからworkflowをdispatchします。
-
-```bash
-gh workflow run release.yml --ref main -f version=v0.1.0
-```
-
-workflowはtagとassetを持つdraft releaseを作成します。release notesを確認してから
-GitHub上で手動publishします。suffix付きversionはprereleaseとして作成され、
-`releases/latest`のinstall経路には入りません。
-
 ## License
 
-[LICENSE](LICENSE)
+xcode-simulator-host is available under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -8,17 +8,18 @@ Apple が公開していない Xcode 27 の設定を利用する実験的なツ�
 
 ## Quick Start
 
-Xcode 27 と Xcode 26 を終了してから、リポジトリ内で次を実行します。
+Xcode 27 を開いたまま、リポジトリ内で次を実行できます。
 
 ```bash
 swift run -c release xcode-simulator-host status
 swift run -c release xcode-simulator-host use legacy
 ```
 
-`use legacy` は設定変更後に、検証済みの Xcode 26 内の Simulator を開きます。
-その後 Xcode 27 を開き、通常どおり GUI から Build & Run します。
+`use legacy` は設定変更後に、選択中のXcode 27に含まれるDevice Hubへ通常終了を
+依頼し、検証済みのXcode 26内のSimulatorを開きます。そのままXcode 27のGUIから
+Build & Runします。
 
-Device Hub 経路へ切り替える場合も、先にすべての Xcode を終了します。
+Device Hub経路へ戻す場合もXcodeを終了する必要はありません。
 
 ```bash
 swift run -c release xcode-simulator-host use device-hub
@@ -70,7 +71,7 @@ xcode-simulator-host restore [--force]
 - `status`: 選択中の Xcode、2つの設定値、Xcode 26 Simulator、復元情報、実行中の
   Xcode を表示します。実設定は変更しません。
 - `use legacy`: Device Hub を経由しない CoreSimulator セッションを選び、Xcode 26
-  の Simulator を開きます。
+  の Simulator を開きます。実行中のDevice Hubは正常終了させます。
 - `use device-hub`: 2つの上書き設定を削除し、Xcode 27 の標準 Device Hub 経路を
   選びます。
 - `restore`: 最初の変更前に保存した2つの設定を復元します。live設定とreceiptが
@@ -78,12 +79,12 @@ xcode-simulator-host restore [--force]
 - `restore --force`: conflictを確認したユーザーの明示操作として、保存済みの元設定を
   現在のBoolean値より優先します。
 
-`use` は、Xcode が1つでも実行中なら設定を変更しません。Simulator の起動だけに
-失敗した場合は、設定変更済みであることをエラーに明記します。その状態も `restore`
-で復元できます。
-
-復元対象がある `restore` も、Xcode が実行中なら停止します。Xcode の設定キャッシュに
-よる再保存と競合させないためです。すべての Xcode を終了して再実行してください。
+`use` と `restore` はXcodeの起動中にも設定を切り替えます。`use legacy` では設定の
+commit後にDevice Hubの終了完了を待ち、設定がまだlegacyであることを再確認してから
+Simulatorを開きます。最終確認からopen完了までは同じoperation lockを保持するため、
+並行する別の切り替えが間へ入ることはありません。Device Hubの終了またはSimulatorの
+起動だけに失敗した場合は、設定変更済みであることをpartial-successエラーに明記します。
+その状態も `restore` で復元できます。
 
 ## Build
 
@@ -117,11 +118,12 @@ install -m 755 .build/release/xcode-simulator-host ~/.local/bin/xcode-simulator-
 receiptに記録した2設定の書き込み途中と同じ値が見つかっても、それがこのツールの
 中断結果か外部変更かは証明できません。この場合も自動復旧せず、`status`は終了コード
 `78`で曖昧な状態を表示します。receiptと現在値を確認し、保存済みの元設定を優先すると
-判断した場合だけ、Xcodeを終了して `restore --force` を実行してください。
+判断した場合だけ `restore --force` を実行してください。Xcodeは開いたままで構いません。
 
 終了コードはBSD `sysexits`に沿います。主な値は `0`（成功または仕様上のno-op）、
 `64`（引数エラー）、`69`（対応するXcode/Simulatorなし）、`74`（I/O失敗）、
-`75`（Xcode実行中またはlock競合）、`78`（設定不整合・receipt conflict）です。
+`75`（lock競合、またはDevice Hubの正常終了失敗）、`78`（設定不整合・receipt
+conflict）です。
 `status` はconflictの内容をstdoutへ表示し、`78`で終了します。
 
 アンインストールや状態ファイルの削除より先に `restore` を実行してください。
@@ -134,6 +136,12 @@ Xcode だけに限定するものではありません。
 ファイルに加えてApple code signatureを検証します。外側はidentifier
 `com.apple.dt.Xcode`、内側は `com.apple.iphonesimulator` とApple anchorを満たし、
 Simulatorの署名済み `DTXcode` もmajor 26である場合だけ開きます。
+
+終了対象のDevice Hubも、選択中Xcode内の検証済みbundle URLと完全一致するものに
+限定します。同じbundle identifierを名乗る別pathのprocessは終了しません。終了要求後は
+`NSRunningApplication.isTerminated` のKVOで完了を確認し、`NSWorkspace`のfull inventoryを
+読み直します。再起動したinstanceを含めて最大10秒間、実行中の対象が0になるまで収束
+させます。強制終了は行いません。
 
 設計、管理する設定、トランザクション、失敗意味論の詳細は
 [Documentation/Design.md](Documentation/Design.md) を参照してください。

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ DEVELOPER_DIR=/Applications/Xcode_27.app/Contents/Developer \
   swift run -c release xcode-simulator-host status
 ```
 
-従来型 Simulator は `/Applications` と `~/Applications` にある検証済み Xcode 26
-のうち、最も新しいものを選びます。明示する場合は絶対パスを渡します。
+従来型 Simulator は `/Applications` にある検証済み Xcode 26 のうち、最も新しい
+ものを選びます。別の場所にあるXcodeを明示する場合は絶対パスを渡します。
 
 ```bash
 swift run -c release xcode-simulator-host use legacy \
@@ -130,9 +130,10 @@ Xcode の設定ドメイン `com.apple.dt.Xcode` はインストールごとで�
 このツールで選択した Xcode 27 は互換性確認の対象であり、設定の適用先をその
 Xcode だけに限定するものではありません。
 
-自動探索または `--legacy-xcode` で指定した Simulator は、bundle情報と実行ファイルに
-加えて、identifier `com.apple.iphonesimulator` と Apple anchor を満たすcode signatureを
-検証してから開きます。
+自動探索または `--legacy-xcode` で指定したXcodeとSimulatorは、bundle情報と実行
+ファイルに加えてApple code signatureを検証します。外側はidentifier
+`com.apple.dt.Xcode`、内側は `com.apple.iphonesimulator` とApple anchorを満たし、
+Simulatorの署名済み `DTXcode` もmajor 26である場合だけ開きます。
 
 設計、管理する設定、トランザクション、失敗意味論の詳細は
 [Documentation/Design.md](Documentation/Design.md) を参照してください。

--- a/README.md
+++ b/README.md
@@ -153,3 +153,7 @@ Simulatorの署名済み `DTXcode` もmajor 26である場合だけ開きます�
 ```bash
 swift test
 ```
+
+## License
+
+[LICENSE](LICENSE)

--- a/Sources/XcodeSimulatorHost/CLIError.swift
+++ b/Sources/XcodeSimulatorHost/CLIError.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+struct CLIError: Error, Equatable, LocalizedError {
+    enum Category: Int32, Equatable {
+        case usage = 64
+        case unavailable = 69
+        case software = 70
+        case cannotCreate = 73
+        case io = 74
+        case temporary = 75
+        case configuration = 78
+    }
+
+    let category: Category
+    let identifier: String
+    let message: String
+
+    var errorDescription: String? {
+        message
+    }
+
+    var rendered: String {
+        "error[\(identifier)]: \(message)"
+    }
+
+    static func usage(_ message: String) -> CLIError {
+        CLIError(category: .usage, identifier: "usage", message: message)
+    }
+
+    static func unavailable(_ identifier: String, _ message: String) -> CLIError {
+        CLIError(category: .unavailable, identifier: identifier, message: message)
+    }
+
+    static func software(_ identifier: String, _ message: String) -> CLIError {
+        CLIError(category: .software, identifier: identifier, message: message)
+    }
+
+    static func cannotCreate(_ identifier: String, _ message: String) -> CLIError {
+        CLIError(category: .cannotCreate, identifier: identifier, message: message)
+    }
+
+    static func io(_ identifier: String, _ message: String) -> CLIError {
+        CLIError(category: .io, identifier: identifier, message: message)
+    }
+
+    static func temporary(_ identifier: String, _ message: String) -> CLIError {
+        CLIError(category: .temporary, identifier: identifier, message: message)
+    }
+
+    static func configuration(_ identifier: String, _ message: String) -> CLIError {
+        CLIError(category: .configuration, identifier: identifier, message: message)
+    }
+}

--- a/Sources/XcodeSimulatorHost/CommandLine/XcodeSimulatorHostApplication.swift
+++ b/Sources/XcodeSimulatorHost/CommandLine/XcodeSimulatorHostApplication.swift
@@ -1,0 +1,91 @@
+import ArgumentParser
+import Foundation
+
+@MainActor
+struct XcodeSimulatorHostApplication {
+    let controller: HostModeController
+
+    static func live() throws -> XcodeSimulatorHostApplication {
+        let runner = SystemCommandRunner()
+        let defaultsStore = DefaultsStore(runner: runner)
+        let receiptStore = try ReceiptStore()
+        let inspector = InstallationInspector(runner: runner)
+        let controller = HostModeController(
+            defaultsStore: defaultsStore,
+            receiptStore: receiptStore,
+            installationInspector: inspector,
+            workspace: .live
+        )
+        return XcodeSimulatorHostApplication(controller: controller)
+    }
+
+    func run(_ command: XcodeSimulatorHostCommand) async throws -> (String, Int32) {
+        switch command {
+        case .status(let legacyXcode):
+            let status = try controller.status(explicitLegacyXcodeURL: legacyXcode)
+            let exitCode = status.receiptStatus.hasConflict
+                ? CLIError.Category.configuration.rawValue
+                : 0
+            return (status.rendered, exitCode)
+
+        case .use(let mode, let legacyXcode):
+            let report = try await controller.use(
+                mode: mode,
+                explicitLegacyXcodeURL: legacyXcode
+            )
+            return (report.rendered, 0)
+
+        case .restore(let force):
+            return (try controller.restore(force: force).rendered, 0)
+        }
+    }
+}
+
+@MainActor
+func runXcodeSimulatorHostCommand(
+    _ arguments: [String],
+    applicationProvider: @MainActor () throws -> XcodeSimulatorHostApplication =
+        XcodeSimulatorHostApplication.live,
+    outputLogger: (String) -> Void = logStandardOutput,
+    errorLogger: (String) -> Void = logStandardError
+) async -> Int32 {
+    let command: XcodeSimulatorHostCommand
+    do {
+        command = try parseXcodeSimulatorHostCommand(arguments)
+    } catch {
+        let message = XcodeSimulatorHostArguments.fullMessage(for: error)
+        let exitCode = XcodeSimulatorHostArguments.exitCode(for: error).rawValue
+        let logger = exitCode == 0 ? outputLogger : errorLogger
+        logger(message)
+        return exitCode
+    }
+
+    do {
+        let application = try applicationProvider()
+        let result = try await application.run(command)
+        outputLogger(result.0)
+        return result.1
+    } catch let error as CLIError {
+        errorLogger(error.rendered)
+        return error.category.rawValue
+    } catch {
+        errorLogger(
+            CLIError.software(
+                "unexpected-error",
+                error.localizedDescription
+            ).rendered
+        )
+        return CLIError.Category.software.rawValue
+    }
+}
+
+private func logStandardOutput(_ message: String) {
+    print(message)
+}
+
+private func logStandardError(_ message: String) {
+    guard let data = "\(message)\n".data(using: .utf8) else {
+        return
+    }
+    FileHandle.standardError.write(data)
+}

--- a/Sources/XcodeSimulatorHost/CommandLine/XcodeSimulatorHostArguments.swift
+++ b/Sources/XcodeSimulatorHost/CommandLine/XcodeSimulatorHostArguments.swift
@@ -1,0 +1,106 @@
+import ArgumentParser
+import Foundation
+
+struct AbsolutePath: ExpressibleByArgument, Equatable {
+    let url: URL
+
+    init?(argument: String) {
+        let path = argument.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard path.hasPrefix("/") else {
+            return nil
+        }
+        url = URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL
+    }
+}
+
+struct XcodeSimulatorHostArguments: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: ToolConstants.name,
+        abstract: "Select the simulator UI host used with Xcode 27.",
+        discussion: """
+            Xcode is resolved from DEVELOPER_DIR or xcode-select. The managed
+            com.apple.dt.Xcode preference is shared by every installed Xcode.
+            Quit all Xcode processes before changing modes.
+            """,
+        version: ToolConstants.version,
+        subcommands: [StatusArguments.self, UseArguments.self, RestoreArguments.self]
+    )
+}
+
+struct StatusArguments: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "status",
+        abstract: "Show the selected Xcode, managed preferences, and restoration receipt."
+    )
+
+    @Option(
+        name: .customLong("legacy-xcode"),
+        help: "Inspect a specific Xcode 26 application as the legacy host.",
+        completion: .file(extensions: ["app"])
+    )
+    var legacyXcode: AbsolutePath?
+}
+
+struct UseArguments: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "use",
+        abstract: "Select a simulator host mode.",
+        subcommands: [UseLegacyArguments.self, UseDeviceHubArguments.self]
+    )
+}
+
+struct UseLegacyArguments: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "legacy",
+        abstract: "Bypass Device Hub and open the Simulator from Xcode 26."
+    )
+
+    @Option(
+        name: .customLong("legacy-xcode"),
+        help: "Use a specific Xcode 26 application as the legacy host.",
+        completion: .file(extensions: ["app"])
+    )
+    var legacyXcode: AbsolutePath?
+}
+
+struct UseDeviceHubArguments: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "device-hub",
+        abstract: "Use Xcode 27's default Device Hub route."
+    )
+}
+
+struct RestoreArguments: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "restore",
+        abstract: "Restore the exact preferences captured before first use."
+    )
+
+    @Flag(
+        help: "Overwrite a conflicting Boolean state with the saved original values."
+    )
+    var force = false
+}
+
+enum XcodeSimulatorHostCommand: Equatable {
+    case status(legacyXcode: URL?)
+    case use(mode: HostMode, legacyXcode: URL?)
+    case restore(force: Bool)
+}
+
+func parseXcodeSimulatorHostCommand(_ arguments: [String]) throws -> XcodeSimulatorHostCommand {
+    var parsed = try XcodeSimulatorHostArguments.parseAsRoot(Array(arguments.dropFirst()))
+    switch parsed {
+    case let command as StatusArguments:
+        return .status(legacyXcode: command.legacyXcode?.url)
+    case let command as UseLegacyArguments:
+        return .use(mode: .legacy, legacyXcode: command.legacyXcode?.url)
+    case is UseDeviceHubArguments:
+        return .use(mode: .deviceHub, legacyXcode: nil)
+    case let command as RestoreArguments:
+        return .restore(force: command.force)
+    default:
+        try parsed.run()
+        preconditionFailure("ArgumentParser returned an unhandled command that did not exit")
+    }
+}

--- a/Sources/XcodeSimulatorHost/CommandLine/XcodeSimulatorHostArguments.swift
+++ b/Sources/XcodeSimulatorHost/CommandLine/XcodeSimulatorHostArguments.swift
@@ -20,7 +20,7 @@ struct XcodeSimulatorHostArguments: ParsableCommand {
         discussion: """
             Xcode is resolved from DEVELOPER_DIR or xcode-select. The managed
             com.apple.dt.Xcode preference is shared by every installed Xcode.
-            Quit all Xcode processes before changing modes.
+            Xcode can remain open while modes change.
             """,
         version: ToolConstants.version,
         subcommands: [StatusArguments.self, UseArguments.self, RestoreArguments.self]

--- a/Sources/XcodeSimulatorHost/HostModeController.swift
+++ b/Sources/XcodeSimulatorHost/HostModeController.swift
@@ -1,0 +1,456 @@
+import Darwin
+import Foundation
+
+@MainActor
+struct HostModeController {
+    private struct ManagedContext {
+        var receipt: RestorationReceipt?
+        let observed: ManagedPreferenceState
+    }
+
+    private let defaultsStore: DefaultsStore
+    private let receiptStore: ReceiptStore
+    private let installationInspector: InstallationInspector
+    private let workspace: WorkspaceClient
+    private let now: () -> Date
+    private let effectiveUserID: uid_t
+
+    init(
+        defaultsStore: DefaultsStore,
+        receiptStore: ReceiptStore,
+        installationInspector: InstallationInspector,
+        workspace: WorkspaceClient,
+        now: @escaping () -> Date = Date.init,
+        effectiveUserID: uid_t = Darwin.geteuid()
+    ) {
+        self.defaultsStore = defaultsStore
+        self.receiptStore = receiptStore
+        self.installationInspector = installationInspector
+        self.workspace = workspace
+        self.now = now
+        self.effectiveUserID = effectiveUserID
+    }
+
+    func status(explicitLegacyXcodeURL: URL?) throws -> HostStatus {
+        try receiptStore.withExclusiveLock {
+            let xcode = try installationInspector.validatedTargetXcode()
+            let preferences = try defaultsStore.readState()
+            let legacySimulator: SimulatorInstallation?
+            if let explicitLegacyXcodeURL {
+                legacySimulator = try installationInspector.legacySimulator(
+                    explicitXcodeURL: explicitLegacyXcodeURL
+                )
+            } else {
+                legacySimulator = try? installationInspector.legacySimulator(
+                    explicitXcodeURL: nil
+                )
+            }
+
+            let receipt = try receiptStore.load()
+            let receiptStatus = classify(receipt: receipt, observed: preferences)
+            return HostStatus(
+                xcode: xcode,
+                preferences: preferences,
+                legacySimulator: legacySimulator,
+                receiptStatus: receiptStatus,
+                receiptURL: receiptStore.receiptURL,
+                runningXcodes: workspace.runningXcodes()
+            )
+        }
+    }
+
+    func use(
+        mode: HostMode,
+        explicitLegacyXcodeURL: URL?
+    ) async throws -> ModeChangeReport {
+        try rejectRootMutation()
+
+        let prepared = try receiptStore.withExclusiveLock {
+            let xcode = try installationInspector.validatedTargetXcode()
+            let simulator: SimulatorInstallation?
+            switch mode {
+            case .legacy:
+                simulator = try installationInspector.legacySimulator(
+                    explicitXcodeURL: explicitLegacyXcodeURL
+                )
+            case .deviceHub:
+                simulator = nil
+            }
+
+            try rejectRunningXcodes()
+
+            let didChange = try transition(
+                to: mode.targetState,
+                capturingWith: xcode
+            )
+            let receiptURL: URL? = try receiptStore.load() == nil
+                ? nil
+                : receiptStore.receiptURL
+            return (
+                xcode: xcode,
+                simulator: simulator,
+                didChange: didChange,
+                receiptURL: receiptURL
+            )
+        }
+
+        if let simulator = prepared.simulator {
+            do {
+                _ = try await workspace.openApplication(simulator.applicationURL)
+            } catch {
+                let detail = errorMessage(error)
+                let recoveryGuidance: String
+                if prepared.receiptURL != nil {
+                    recoveryGuidance = "The preferences remain managed; run restore to undo them."
+                } else {
+                    recoveryGuidance = "No restoration receipt exists because these are the original preferences."
+                }
+                throw CLIError.io(
+                    "simulator-launch-partial-success",
+                    "legacy mode is configured, but Simulator could not be opened: \(detail). \(recoveryGuidance)"
+                )
+            }
+        }
+
+        return ModeChangeReport(
+            mode: mode,
+            didChange: prepared.didChange,
+            xcode: prepared.xcode,
+            simulator: prepared.simulator,
+            receiptURL: prepared.receiptURL
+        )
+    }
+
+    func restore(force: Bool = false) throws -> RestoreReport {
+        try rejectRootMutation()
+
+        return try receiptStore.withExclusiveLock {
+            guard let receipt = try receiptStore.load() else {
+                return RestoreReport(
+                    didRestore: false,
+                    restoredState: nil,
+                    receiptURL: receiptStore.receiptURL
+                )
+            }
+            try rejectRunningXcodes()
+
+            if force {
+                return try forceRestore(receipt)
+            }
+
+            let context = try recoverManagedContext()
+            guard let receipt = context.receipt else {
+                return RestoreReport(
+                    didRestore: false,
+                    restoredState: nil,
+                    receiptURL: receiptStore.receiptURL
+                )
+            }
+
+            let didChange = try transition(
+                to: receipt.original,
+                capturingWith: nil
+            )
+            return RestoreReport(
+                didRestore: didChange,
+                restoredState: receipt.original,
+                receiptURL: receiptStore.receiptURL
+            )
+        }
+    }
+
+    private func transition(
+        to target: ManagedPreferenceState,
+        capturingWith xcode: XcodeInstallation?
+    ) throws -> Bool {
+        var context = try recoverManagedContext()
+        let before = context.observed
+
+        if context.receipt == nil {
+            guard before != target else {
+                return false
+            }
+            guard let xcode else {
+                throw CLIError.software(
+                    "missing-capture-xcode",
+                    "a new restoration receipt requires a validated Xcode"
+                )
+            }
+            let receipt = RestorationReceipt(
+                capturedAt: now(),
+                xcode: xcode,
+                original: before
+            )
+            try receiptStore.save(receipt)
+            context.receipt = receipt
+        }
+
+        guard var receipt = context.receipt else {
+            throw CLIError.software(
+                "missing-receipt",
+                "preference transition lost its restoration receipt"
+            )
+        }
+        guard before == receipt.expectedCurrent else {
+            throw conflictError(expected: receipt.expectedCurrent, observed: before)
+        }
+        guard before != target else {
+            return false
+        }
+
+        receipt.pending = PendingMutation(before: before, target: target)
+        try receiptStore.save(receipt)
+
+        do {
+            _ = try defaultsStore.apply(target, from: before)
+        } catch let mismatch as DefaultsStore.StateMismatch {
+            throw conflictError(
+                expected: before,
+                observed: mismatch.observed
+            )
+        } catch {
+            try rollback(
+                after: error,
+                to: before,
+                attemptedTarget: target,
+                receipt: receipt
+            )
+        }
+
+        if target == receipt.original {
+            try receiptStore.deleteReceipt()
+        } else {
+            receipt.expectedCurrent = target
+            receipt.pending = nil
+            try receiptStore.save(receipt)
+        }
+        return true
+    }
+
+    private func recoverManagedContext() throws -> ManagedContext {
+        guard var receipt = try receiptStore.load() else {
+            return ManagedContext(
+                receipt: nil,
+                observed: try defaultsStore.readState()
+            )
+        }
+
+        let observed = try defaultsStore.readState()
+        if let pending = receipt.pending {
+            if observed == pending.before {
+                if observed == receipt.original {
+                    try receiptStore.deleteReceipt()
+                    return ManagedContext(
+                        receipt: nil,
+                        observed: observed
+                    )
+                }
+                receipt.expectedCurrent = observed
+                receipt.pending = nil
+                try receiptStore.save(receipt)
+                return ManagedContext(
+                    receipt: receipt,
+                    observed: observed
+                )
+            }
+            if observed == pending.target {
+                if observed == receipt.original {
+                    try receiptStore.deleteReceipt()
+                    return ManagedContext(
+                        receipt: nil,
+                        observed: observed
+                    )
+                }
+                receipt.expectedCurrent = observed
+                receipt.pending = nil
+                try receiptStore.save(receipt)
+                return ManagedContext(
+                    receipt: receipt,
+                    observed: observed
+                )
+            }
+            if defaultsStore.isAmbiguousIntermediate(
+                observed,
+                from: pending.before,
+                to: pending.target
+            ) {
+                throw CLIError.configuration(
+                    "ambiguous-intermediate",
+                    "the live preferences match a possible interrupted write, but the tool cannot distinguish that from an external change. Nothing was overwritten. Inspect \(receiptStore.receiptURL.path), then use restore --force only if the saved original should win."
+                )
+            }
+            throw conflictError(
+                expected: receipt.expectedCurrent,
+                observed: observed
+            )
+        }
+
+        guard observed == receipt.expectedCurrent else {
+            throw conflictError(expected: receipt.expectedCurrent, observed: observed)
+        }
+        if observed == receipt.original {
+            try receiptStore.deleteReceipt()
+            return ManagedContext(
+                receipt: nil,
+                observed: observed
+            )
+        }
+        return ManagedContext(
+            receipt: receipt,
+            observed: observed
+        )
+    }
+
+    private func forceRestore(_ receipt: RestorationReceipt) throws -> RestoreReport {
+        let observed = try defaultsStore.readState()
+        guard observed != receipt.original else {
+            try receiptStore.deleteReceipt()
+            return RestoreReport(
+                didRestore: false,
+                restoredState: receipt.original,
+                receiptURL: receiptStore.receiptURL
+            )
+        }
+
+        var forcedReceipt = receipt
+        forcedReceipt.expectedCurrent = observed
+        forcedReceipt.pending = PendingMutation(
+            before: observed,
+            target: receipt.original
+        )
+        try receiptStore.save(forcedReceipt)
+
+        do {
+            _ = try defaultsStore.apply(receipt.original, from: observed)
+        } catch let mismatch as DefaultsStore.StateMismatch {
+            throw conflictError(expected: observed, observed: mismatch.observed)
+        } catch {
+            try rollback(
+                after: error,
+                to: observed,
+                attemptedTarget: receipt.original,
+                receipt: forcedReceipt
+            )
+        }
+
+        try receiptStore.deleteReceipt()
+        return RestoreReport(
+            didRestore: true,
+            restoredState: receipt.original,
+            receiptURL: receiptStore.receiptURL
+        )
+    }
+
+    private func rollback(
+        after primaryError: any Error,
+        to before: ManagedPreferenceState,
+        attemptedTarget: ManagedPreferenceState,
+        receipt: RestorationReceipt
+    ) throws -> Never {
+        do {
+            _ = try defaultsStore.rollback(
+                to: before,
+                fromAttemptedTarget: attemptedTarget
+            )
+        } catch let mismatch as DefaultsStore.StateMismatch {
+            throw CLIError.configuration(
+                "inconsistent-preferences",
+                "transition failed (\(errorMessage(primaryError))) and rollback refused to overwrite an unexpected state (\(mismatch.observed)). Recovery data remains at \(receiptStore.receiptURL.path)"
+            )
+        } catch {
+            throw CLIError.configuration(
+                "inconsistent-preferences",
+                "transition failed (\(errorMessage(primaryError))) and rollback failed (\(errorMessage(error))). Recovery data remains at \(receiptStore.receiptURL.path)"
+            )
+        }
+
+        do {
+            if before == receipt.original {
+                try receiptStore.deleteReceipt()
+            } else {
+                var restoredReceipt = receipt
+                restoredReceipt.expectedCurrent = before
+                restoredReceipt.pending = nil
+                try receiptStore.save(restoredReceipt)
+            }
+        } catch {
+            throw CLIError.io(
+                "rollback-receipt",
+                "preferences were rolled back after \(errorMessage(primaryError)), but recovery metadata could not be finalized: \(errorMessage(error))"
+            )
+        }
+
+        throw CLIError.io(
+            "transition-rolled-back",
+            "preference transition failed and was rolled back: \(errorMessage(primaryError))"
+        )
+    }
+
+    private func classify(
+        receipt: RestorationReceipt?,
+        observed: ManagedPreferenceState
+    ) -> ReceiptStatus {
+        guard let receipt else {
+            return .unmanaged
+        }
+        if let pending = receipt.pending {
+            if observed == pending.before {
+                return .pendingBefore
+            }
+            if observed == pending.target {
+                return .pendingTarget
+            }
+            if defaultsStore.isAmbiguousIntermediate(
+                observed,
+                from: pending.before,
+                to: pending.target
+            ) {
+                return .ambiguousIntermediate
+            }
+            return .conflict(expected: receipt.expectedCurrent, observed: observed)
+        }
+        guard observed == receipt.expectedCurrent else {
+            return .conflict(expected: receipt.expectedCurrent, observed: observed)
+        }
+        return .managed(original: receipt.original)
+    }
+
+    private func rejectRootMutation() throws {
+        guard effectiveUserID != 0 else {
+            throw CLIError.configuration(
+                "root-user",
+                "do not run this command with sudo; it manages per-user Xcode preferences"
+            )
+        }
+    }
+
+    private func rejectRunningXcodes() throws {
+        let runningXcodes = workspace.runningXcodes()
+        guard runningXcodes.isEmpty else {
+            let details = runningXcodes.map { application in
+                application.bundleURL?.path ?? "pid \(application.processIdentifier)"
+            }.joined(separator: ", ")
+            throw CLIError.temporary(
+                "xcode-running",
+                "quit every Xcode process before changing modes: \(details)"
+            )
+        }
+    }
+
+    private func conflictError(
+        expected: ManagedPreferenceState,
+        observed: ManagedPreferenceState
+    ) -> CLIError {
+        CLIError.configuration(
+            "preference-conflict",
+            "managed preferences changed outside this tool; expected \(expected), observed \(observed). Inspect \(receiptStore.receiptURL.path) before recovering."
+        )
+    }
+
+    private func errorMessage(_ error: any Error) -> String {
+        if let error = error as? CLIError {
+            return error.message
+        }
+        return error.localizedDescription
+    }
+}

--- a/Sources/XcodeSimulatorHost/HostModeController.swift
+++ b/Sources/XcodeSimulatorHost/HostModeController.swift
@@ -65,7 +65,7 @@ struct HostModeController {
     ) async throws -> ModeChangeReport {
         try rejectRootMutation()
 
-        let prepared = try receiptStore.withExclusiveLock {
+        return try await receiptStore.withExclusiveLock {
             let xcode = try installationInspector.validatedTargetXcode()
             let simulator: SimulatorInstallation?
             switch mode {
@@ -84,65 +84,69 @@ struct HostModeController {
             let receiptURL: URL? = try receiptStore.load() == nil
                 ? nil
                 : receiptStore.receiptURL
-            return (
+
+            var terminatedDeviceHubCount = 0
+            if let simulator {
+                var deviceHubTerminationError: (any Error)?
+                do {
+                    let deviceHubURL = xcode.applicationURL
+                        .appendingPathComponent(
+                            ToolConstants.deviceHubPath,
+                            isDirectory: true
+                        )
+                    terminatedDeviceHubCount = try await workspace.terminateDeviceHubs(
+                        deviceHubURL
+                    )
+                } catch {
+                    deviceHubTerminationError = error
+                }
+
+                var simulatorLaunchError: (any Error)?
+                do {
+                    let observed = try defaultsStore.readState()
+                    guard observed == mode.targetState else {
+                        throw conflictError(
+                            expected: mode.targetState,
+                            observed: observed
+                        )
+                    }
+                    do {
+                        _ = try await workspace.openApplication(
+                            simulator.applicationURL
+                        )
+                    } catch {
+                        simulatorLaunchError = error
+                    }
+                } catch {
+                    let category = (error as? CLIError)?.category ?? .io
+                    let terminationDetail = deviceHubTerminationError.map {
+                        " Device Hub also could not be closed: \(errorMessage($0))."
+                    } ?? ""
+                    throw CLIError(
+                        category: category,
+                        identifier: "legacy-host-invalidated",
+                        message: "legacy mode was committed, but it could not be held through the final Simulator open: \(errorMessage(error)). Simulator was not opened.\(terminationDetail)"
+                    )
+                }
+
+                if deviceHubTerminationError != nil || simulatorLaunchError != nil {
+                    throw legacyHostPartialSuccessError(
+                        receiptURL: receiptURL,
+                        deviceHubTerminationError: deviceHubTerminationError,
+                        simulatorLaunchError: simulatorLaunchError
+                    )
+                }
+            }
+
+            return ModeChangeReport(
+                mode: mode,
+                didChange: didChange,
                 xcode: xcode,
                 simulator: simulator,
-                didChange: didChange,
-                receiptURL: receiptURL
+                receiptURL: receiptURL,
+                terminatedDeviceHubCount: terminatedDeviceHubCount
             )
         }
-
-        var terminatedDeviceHubCount = 0
-        if let simulator = prepared.simulator {
-            var deviceHubTerminationError: (any Error)?
-            do {
-                let deviceHubURL = prepared.xcode.applicationURL
-                    .appendingPathComponent(
-                        ToolConstants.deviceHubPath,
-                        isDirectory: true
-                    )
-                terminatedDeviceHubCount = try await workspace.terminateDeviceHubs(
-                    deviceHubURL
-                )
-            } catch {
-                deviceHubTerminationError = error
-            }
-
-            var simulatorLaunchError: (any Error)?
-            do {
-                simulatorLaunchError = try await openLegacySimulatorIfCommitted(
-                    expected: mode.targetState,
-                    applicationURL: simulator.applicationURL
-                )
-            } catch {
-                let category = (error as? CLIError)?.category ?? .io
-                let terminationDetail = deviceHubTerminationError.map {
-                    " Device Hub also could not be closed: \(errorMessage($0))."
-                } ?? ""
-                throw CLIError(
-                    category: category,
-                    identifier: "legacy-host-invalidated",
-                    message: "legacy mode was committed, but it could not be held through the final Simulator open: \(errorMessage(error)). Simulator was not opened.\(terminationDetail)"
-                )
-            }
-
-            if deviceHubTerminationError != nil || simulatorLaunchError != nil {
-                throw legacyHostPartialSuccessError(
-                    receiptURL: prepared.receiptURL,
-                    deviceHubTerminationError: deviceHubTerminationError,
-                    simulatorLaunchError: simulatorLaunchError
-                )
-            }
-        }
-
-        return ModeChangeReport(
-            mode: mode,
-            didChange: prepared.didChange,
-            xcode: prepared.xcode,
-            simulator: prepared.simulator,
-            receiptURL: prepared.receiptURL,
-            terminatedDeviceHubCount: terminatedDeviceHubCount
-        )
     }
 
     func restore(force: Bool = false) throws -> RestoreReport {
@@ -443,24 +447,6 @@ struct HostModeController {
                 "root-user",
                 "do not run this command with sudo; it manages per-user Xcode preferences"
             )
-        }
-    }
-
-    private func openLegacySimulatorIfCommitted(
-        expected: ManagedPreferenceState,
-        applicationURL: URL
-    ) async throws -> (any Error)? {
-        try await receiptStore.withExclusiveLock {
-            let observed = try defaultsStore.readState()
-            guard observed == expected else {
-                throw conflictError(expected: expected, observed: observed)
-            }
-            do {
-                _ = try await workspace.openApplication(applicationURL)
-                return nil
-            } catch {
-                return error
-            }
         }
     }
 

--- a/Sources/XcodeSimulatorHost/HostModeController.swift
+++ b/Sources/XcodeSimulatorHost/HostModeController.swift
@@ -32,30 +32,15 @@ struct HostModeController {
     }
 
     func status(explicitLegacyXcodeURL: URL?) throws -> HostStatus {
-        try receiptStore.withExclusiveLock {
-            let xcode = try installationInspector.validatedTargetXcode()
-            let preferences = try defaultsStore.readState()
-            let legacySimulator: SimulatorInstallation?
-            if let explicitLegacyXcodeURL {
-                legacySimulator = try installationInspector.legacySimulator(
-                    explicitXcodeURL: explicitLegacyXcodeURL
-                )
-            } else {
-                legacySimulator = try? installationInspector.legacySimulator(
-                    explicitXcodeURL: nil
-                )
+        if try !receiptStore.stateDirectoryExists() {
+            let snapshot = try makeStatus(explicitLegacyXcodeURL: explicitLegacyXcodeURL)
+            if try !receiptStore.stateDirectoryExists() {
+                return snapshot
             }
+        }
 
-            let receipt = try receiptStore.load()
-            let receiptStatus = classify(receipt: receipt, observed: preferences)
-            return HostStatus(
-                xcode: xcode,
-                preferences: preferences,
-                legacySimulator: legacySimulator,
-                receiptStatus: receiptStatus,
-                receiptURL: receiptStore.receiptURL,
-                runningXcodes: workspace.runningXcodes()
-            )
+        return try receiptStore.withExistingExclusiveLock {
+            try makeStatus(explicitLegacyXcodeURL: explicitLegacyXcodeURL)
         }
     }
 
@@ -152,6 +137,14 @@ struct HostModeController {
     func restore(force: Bool = false) throws -> RestoreReport {
         try rejectRootMutation()
 
+        guard try receiptStore.load() != nil else {
+            return RestoreReport(
+                didRestore: false,
+                restoredState: nil,
+                receiptURL: receiptStore.receiptURL
+            )
+        }
+
         return try receiptStore.withExclusiveLock {
             guard let receipt = try receiptStore.load() else {
                 return RestoreReport(
@@ -183,6 +176,32 @@ struct HostModeController {
                 receiptURL: receiptStore.receiptURL
             )
         }
+    }
+
+    private func makeStatus(explicitLegacyXcodeURL: URL?) throws -> HostStatus {
+        let xcode = try installationInspector.validatedTargetXcode()
+        let preferences = try defaultsStore.readState()
+        let legacySimulator: SimulatorInstallation?
+        if let explicitLegacyXcodeURL {
+            legacySimulator = try installationInspector.legacySimulator(
+                explicitXcodeURL: explicitLegacyXcodeURL
+            )
+        } else {
+            legacySimulator = try? installationInspector.legacySimulator(
+                explicitXcodeURL: nil
+            )
+        }
+
+        let receipt = try receiptStore.load()
+        let receiptStatus = classify(receipt: receipt, observed: preferences)
+        return HostStatus(
+            xcode: xcode,
+            preferences: preferences,
+            legacySimulator: legacySimulator,
+            receiptStatus: receiptStatus,
+            receiptURL: receiptStore.receiptURL,
+            runningXcodes: workspace.runningXcodes()
+        )
     }
 
     private func transition(

--- a/Sources/XcodeSimulatorHost/HostModeController.swift
+++ b/Sources/XcodeSimulatorHost/HostModeController.swift
@@ -137,7 +137,7 @@ struct HostModeController {
     func restore(force: Bool = false) throws -> RestoreReport {
         try rejectRootMutation()
 
-        guard try receiptStore.load() != nil else {
+        guard try receiptStore.stateDirectoryExists() else {
             return RestoreReport(
                 didRestore: false,
                 restoredState: nil,
@@ -145,7 +145,7 @@ struct HostModeController {
             )
         }
 
-        return try receiptStore.withExclusiveLock {
+        return try receiptStore.withExistingExclusiveLock {
             guard let receipt = try receiptStore.load() else {
                 return RestoreReport(
                     didRestore: false,

--- a/Sources/XcodeSimulatorHost/HostModeController.swift
+++ b/Sources/XcodeSimulatorHost/HostModeController.swift
@@ -77,8 +77,6 @@ struct HostModeController {
                 simulator = nil
             }
 
-            try rejectRunningXcodes()
-
             let didChange = try transition(
                 to: mode.targetState,
                 capturingWith: xcode
@@ -94,20 +92,45 @@ struct HostModeController {
             )
         }
 
+        var terminatedDeviceHubCount = 0
         if let simulator = prepared.simulator {
+            var deviceHubTerminationError: (any Error)?
             do {
-                _ = try await workspace.openApplication(simulator.applicationURL)
+                let deviceHubURL = prepared.xcode.applicationURL
+                    .appendingPathComponent(
+                        ToolConstants.deviceHubPath,
+                        isDirectory: true
+                    )
+                terminatedDeviceHubCount = try await workspace.terminateDeviceHubs(
+                    deviceHubURL
+                )
             } catch {
-                let detail = errorMessage(error)
-                let recoveryGuidance: String
-                if prepared.receiptURL != nil {
-                    recoveryGuidance = "The preferences remain managed; run restore to undo them."
-                } else {
-                    recoveryGuidance = "No restoration receipt exists because these are the original preferences."
-                }
-                throw CLIError.io(
-                    "simulator-launch-partial-success",
-                    "legacy mode is configured, but Simulator could not be opened: \(detail). \(recoveryGuidance)"
+                deviceHubTerminationError = error
+            }
+
+            var simulatorLaunchError: (any Error)?
+            do {
+                simulatorLaunchError = try await openLegacySimulatorIfCommitted(
+                    expected: mode.targetState,
+                    applicationURL: simulator.applicationURL
+                )
+            } catch {
+                let category = (error as? CLIError)?.category ?? .io
+                let terminationDetail = deviceHubTerminationError.map {
+                    " Device Hub also could not be closed: \(errorMessage($0))."
+                } ?? ""
+                throw CLIError(
+                    category: category,
+                    identifier: "legacy-host-invalidated",
+                    message: "legacy mode was committed, but it could not be held through the final Simulator open: \(errorMessage(error)). Simulator was not opened.\(terminationDetail)"
+                )
+            }
+
+            if deviceHubTerminationError != nil || simulatorLaunchError != nil {
+                throw legacyHostPartialSuccessError(
+                    receiptURL: prepared.receiptURL,
+                    deviceHubTerminationError: deviceHubTerminationError,
+                    simulatorLaunchError: simulatorLaunchError
                 )
             }
         }
@@ -117,7 +140,8 @@ struct HostModeController {
             didChange: prepared.didChange,
             xcode: prepared.xcode,
             simulator: prepared.simulator,
-            receiptURL: prepared.receiptURL
+            receiptURL: prepared.receiptURL,
+            terminatedDeviceHubCount: terminatedDeviceHubCount
         )
     }
 
@@ -132,8 +156,6 @@ struct HostModeController {
                     receiptURL: receiptStore.receiptURL
                 )
             }
-            try rejectRunningXcodes()
-
             if force {
                 return try forceRestore(receipt)
             }
@@ -424,15 +446,56 @@ struct HostModeController {
         }
     }
 
-    private func rejectRunningXcodes() throws {
-        let runningXcodes = workspace.runningXcodes()
-        guard runningXcodes.isEmpty else {
-            let details = runningXcodes.map { application in
-                application.bundleURL?.path ?? "pid \(application.processIdentifier)"
-            }.joined(separator: ", ")
-            throw CLIError.temporary(
-                "xcode-running",
-                "quit every Xcode process before changing modes: \(details)"
+    private func openLegacySimulatorIfCommitted(
+        expected: ManagedPreferenceState,
+        applicationURL: URL
+    ) async throws -> (any Error)? {
+        try await receiptStore.withExclusiveLock {
+            let observed = try defaultsStore.readState()
+            guard observed == expected else {
+                throw conflictError(expected: expected, observed: observed)
+            }
+            do {
+                _ = try await workspace.openApplication(applicationURL)
+                return nil
+            } catch {
+                return error
+            }
+        }
+    }
+
+    private func legacyHostPartialSuccessError(
+        receiptURL: URL?,
+        deviceHubTerminationError: (any Error)?,
+        simulatorLaunchError: (any Error)?
+    ) -> CLIError {
+        let recoveryGuidance = if receiptURL != nil {
+            "The preferences remain managed; run restore to undo them."
+        } else {
+            "No restoration receipt exists because these are the original preferences."
+        }
+
+        switch (deviceHubTerminationError, simulatorLaunchError) {
+        case let (terminationError?, nil):
+            return CLIError(
+                category: (terminationError as? CLIError)?.category ?? .temporary,
+                identifier: "device-hub-termination-partial-success",
+                message: "legacy mode is configured and Simulator is open, but Device Hub could not be closed: \(errorMessage(terminationError)). \(recoveryGuidance)"
+            )
+        case let (nil, launchError?):
+            return CLIError.io(
+                "simulator-launch-partial-success",
+                "legacy mode is configured, but Simulator could not be opened: \(errorMessage(launchError)). \(recoveryGuidance)"
+            )
+        case let (terminationError?, launchError?):
+            return CLIError.io(
+                "legacy-host-partial-success",
+                "legacy mode is configured, but Device Hub could not be closed (\(errorMessage(terminationError))) and Simulator could not be opened (\(errorMessage(launchError))). \(recoveryGuidance)"
+            )
+        case (nil, nil):
+            return CLIError.software(
+                "legacy-host-partial-success",
+                "legacy host failure was requested without a failing operation"
             )
         }
     }

--- a/Sources/XcodeSimulatorHost/HostModeController.swift
+++ b/Sources/XcodeSimulatorHost/HostModeController.swift
@@ -250,7 +250,7 @@ struct HostModeController {
             _ = try defaultsStore.apply(target, from: before)
         } catch let mismatch as DefaultsStore.StateMismatch {
             throw conflictError(
-                expected: before,
+                expected: mismatch.expected.first ?? before,
                 observed: mismatch.observed
             )
         } catch {

--- a/Sources/XcodeSimulatorHost/HostStatus.swift
+++ b/Sources/XcodeSimulatorHost/HostStatus.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+enum ReceiptStatus: Equatable {
+    case unmanaged
+    case managed(original: ManagedPreferenceState)
+    case pendingBefore
+    case pendingTarget
+    case ambiguousIntermediate
+    case conflict(expected: ManagedPreferenceState, observed: ManagedPreferenceState)
+
+    var hasConflict: Bool {
+        if case .conflict = self {
+            return true
+        }
+        return self == .ambiguousIntermediate
+    }
+}
+
+struct HostStatus: Equatable {
+    let xcode: XcodeInstallation
+    let preferences: ManagedPreferenceState
+    let legacySimulator: SimulatorInstallation?
+    let receiptStatus: ReceiptStatus
+    let receiptURL: URL
+    let runningXcodes: [RunningApplication]
+
+    var rendered: String {
+        var lines = [
+            "Selected Xcode: \(xcode.version) (\(xcode.buildVersion))",
+            "  \(xcode.applicationURL.path)",
+            "Configured host: \(preferences.effectiveMode.rawValue)",
+            "Xcode preference: \(preferences.xcodeSession)",
+            "Device Hub auto-start suppression: \(preferences.deviceHubAutoStartSuppression)",
+        ]
+
+        if let legacySimulator {
+            lines.append(
+                "Legacy Simulator: Xcode \(legacySimulator.xcode.version), Simulator \(legacySimulator.version) (\(legacySimulator.buildVersion))"
+            )
+            lines.append("  \(legacySimulator.applicationURL.path)")
+        } else {
+            lines.append("Legacy Simulator: not found")
+        }
+
+        switch receiptStatus {
+        case .unmanaged:
+            lines.append("Restoration receipt: none")
+        case .managed(let original):
+            lines.append("Restoration receipt: managed (original: \(original))")
+            lines.append("  \(receiptURL.path)")
+        case .pendingBefore:
+            lines.append("Restoration receipt: pending mutation not applied; run a use or restore command to recover")
+            lines.append("  \(receiptURL.path)")
+        case .pendingTarget:
+            lines.append("Restoration receipt: pending mutation applied; run a use or restore command to recover")
+            lines.append("  \(receiptURL.path)")
+        case .ambiguousIntermediate:
+            lines.append("Restoration receipt: AMBIGUOUS INTERMEDIATE STATE")
+            lines.append("  This may be an interrupted write or an external change; nothing will be overwritten automatically.")
+            lines.append("  Inspect the receipt, then use restore --force only if the saved original should win.")
+            lines.append("  \(receiptURL.path)")
+        case .conflict(let expected, let observed):
+            lines.append("Restoration receipt: CONFLICT")
+            lines.append("  expected: \(expected)")
+            lines.append("  observed: \(observed)")
+            lines.append("  \(receiptURL.path)")
+        }
+
+        if runningXcodes.isEmpty {
+            lines.append("Running Xcode processes: none")
+        } else {
+            lines.append("Running Xcode processes: \(runningXcodes.count) (mode changes are blocked)")
+            for application in runningXcodes {
+                let path = application.bundleURL?.path ?? "unknown path"
+                lines.append("  pid \(application.processIdentifier): \(path)")
+            }
+        }
+
+        lines.append("Note: com.apple.dt.Xcode preferences are shared by all installed Xcode versions.")
+        return lines.joined(separator: "\n")
+    }
+}
+
+struct ModeChangeReport: Equatable {
+    let mode: HostMode
+    let didChange: Bool
+    let xcode: XcodeInstallation
+    let simulator: SimulatorInstallation?
+    let receiptURL: URL?
+
+    var rendered: String {
+        var lines: [String]
+        if didChange {
+            lines = ["Configured simulator host: \(mode.rawValue)"]
+        } else {
+            lines = ["Simulator host is already configured for \(mode.rawValue)."]
+        }
+
+        lines.append("Xcode: \(xcode.version) (\(xcode.buildVersion))")
+        if let simulator {
+            lines.append("Simulator: \(simulator.applicationURL.path)")
+        }
+        if let receiptURL {
+            lines.append("Restoration receipt: saved at \(receiptURL.path)")
+        } else if didChange {
+            lines.append("Restoration receipt: removed after returning to the original state")
+        } else {
+            lines.append("Restoration receipt: none")
+        }
+        lines.append("Launch Xcode 27 after changing modes.")
+        return lines.joined(separator: "\n")
+    }
+}
+
+struct RestoreReport: Equatable {
+    let didRestore: Bool
+    let restoredState: ManagedPreferenceState?
+    let receiptURL: URL
+
+    var rendered: String {
+        guard let restoredState else {
+            return "No restoration receipt exists; nothing changed."
+        }
+        if !didRestore {
+            return """
+                Preferences already matched the saved original: \(restoredState)
+                Removed restoration receipt: \(receiptURL.path)
+                """
+        }
+        return """
+            Restored original preferences: \(restoredState)
+            Removed restoration receipt: \(receiptURL.path)
+            Launch Xcode again to use the restored configuration.
+            """
+    }
+}

--- a/Sources/XcodeSimulatorHost/HostStatus.swift
+++ b/Sources/XcodeSimulatorHost/HostStatus.swift
@@ -69,7 +69,7 @@ struct HostStatus: Equatable {
         if runningXcodes.isEmpty {
             lines.append("Running Xcode processes: none")
         } else {
-            lines.append("Running Xcode processes: \(runningXcodes.count) (mode changes are blocked)")
+            lines.append("Running Xcode processes: \(runningXcodes.count) (hot switching is supported)")
             for application in runningXcodes {
                 let path = application.bundleURL?.path ?? "unknown path"
                 lines.append("  pid \(application.processIdentifier): \(path)")
@@ -87,6 +87,7 @@ struct ModeChangeReport: Equatable {
     let xcode: XcodeInstallation
     let simulator: SimulatorInstallation?
     let receiptURL: URL?
+    let terminatedDeviceHubCount: Int
 
     var rendered: String {
         var lines: [String]
@@ -100,6 +101,9 @@ struct ModeChangeReport: Equatable {
         if let simulator {
             lines.append("Simulator: \(simulator.applicationURL.path)")
         }
+        if terminatedDeviceHubCount > 0 {
+            lines.append("Closed Device Hub instances: \(terminatedDeviceHubCount)")
+        }
         if let receiptURL {
             lines.append("Restoration receipt: saved at \(receiptURL.path)")
         } else if didChange {
@@ -107,7 +111,7 @@ struct ModeChangeReport: Equatable {
         } else {
             lines.append("Restoration receipt: none")
         }
-        lines.append("Launch Xcode 27 after changing modes.")
+        lines.append("Xcode 27 can remain open; the next Run uses this mode.")
         return lines.joined(separator: "\n")
     }
 }
@@ -130,7 +134,7 @@ struct RestoreReport: Equatable {
         return """
             Restored original preferences: \(restoredState)
             Removed restoration receipt: \(receiptURL.path)
-            Launch Xcode again to use the restored configuration.
+            Xcode can remain open; the next Run uses the restored configuration.
             """
     }
 }

--- a/Sources/XcodeSimulatorHost/Installations/InstallationInspector.swift
+++ b/Sources/XcodeSimulatorHost/Installations/InstallationInspector.swift
@@ -22,8 +22,6 @@ struct InstallationInspector {
         self.signatureValidator = signatureValidator
         self.legacySearchRoots = legacySearchRoots ?? [
             URL(fileURLWithPath: "/Applications", isDirectory: true),
-            fileManager.homeDirectoryForCurrentUser
-                .appendingPathComponent("Applications", isDirectory: true),
         ]
     }
 
@@ -193,6 +191,10 @@ struct InstallationInspector {
                 "legacy Simulator must come from Xcode 26, found Xcode \(xcode.version)"
             )
         }
+        try signatureValidator.validateAppleApplication(
+            xcode.applicationURL,
+            ToolConstants.xcodeBundleIdentifier
+        )
 
         let simulatorURL = xcode.applicationURL
             .appendingPathComponent(ToolConstants.simulatorPath, isDirectory: true)
@@ -200,11 +202,14 @@ struct InstallationInspector {
         guard info["CFBundleIdentifier"] as? String == ToolConstants.simulatorBundleIdentifier,
               let executable = info["CFBundleExecutable"] as? String,
               let version = info["CFBundleShortVersionString"] as? String,
-              let buildVersion = info["CFBundleVersion"] as? String
+              let buildVersion = info["CFBundleVersion"] as? String,
+              let dtXcodeString = info["DTXcode"] as? String,
+              let dtXcode = Int(dtXcodeString),
+              dtXcode / 100 == ToolConstants.legacyXcodeMajorVersion
         else {
             throw CLIError.unavailable(
                 "legacy-simulator-bundle",
-                "\(simulatorURL.path) is not a valid Simulator application"
+                "\(simulatorURL.path) is not a valid Xcode 26 Simulator application"
             )
         }
 

--- a/Sources/XcodeSimulatorHost/Installations/InstallationInspector.swift
+++ b/Sources/XcodeSimulatorHost/Installations/InstallationInspector.swift
@@ -1,0 +1,295 @@
+import Foundation
+
+struct InstallationInspector {
+    private static let xcodeSelect = URL(fileURLWithPath: "/usr/bin/xcode-select")
+
+    private let runner: any CommandRunning
+    private let fileManager: FileManager
+    private let environment: [String: String]
+    private let legacySearchRoots: [URL]
+    private let signatureValidator: CodeSignatureValidator
+
+    init(
+        runner: any CommandRunning,
+        fileManager: FileManager = .default,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        legacySearchRoots: [URL]? = nil,
+        signatureValidator: CodeSignatureValidator = .live
+    ) {
+        self.runner = runner
+        self.fileManager = fileManager
+        self.environment = environment
+        self.signatureValidator = signatureValidator
+        self.legacySearchRoots = legacySearchRoots ?? [
+            URL(fileURLWithPath: "/Applications", isDirectory: true),
+            fileManager.homeDirectoryForCurrentUser
+                .appendingPathComponent("Applications", isDirectory: true),
+        ]
+    }
+
+    func validatedTargetXcode() throws -> XcodeInstallation {
+        let developerDirectory = try selectedDeveloperDirectory()
+        let xcodeURL = try xcodeApplicationURL(forDeveloperDirectory: developerDirectory)
+        let xcode = try inspectXcode(at: xcodeURL)
+
+        guard xcode.version.major == ToolConstants.supportedXcodeMajorVersion else {
+            throw CLIError.unavailable(
+                "unsupported-xcode",
+                "Xcode \(xcode.version) is selected; only Xcode 27 is supported"
+            )
+        }
+
+        let deviceHubURL = xcode.applicationURL
+            .appendingPathComponent(ToolConstants.deviceHubPath, isDirectory: true)
+        let deviceHubInfo = try propertyList(
+            at: deviceHubURL.appendingPathComponent("Contents/Info.plist")
+        )
+        guard deviceHubInfo["CFBundleIdentifier"] as? String
+                == ToolConstants.deviceHubBundleIdentifier,
+              let deviceHubExecutable = deviceHubInfo["CFBundleExecutable"] as? String
+        else {
+            throw CLIError.unavailable(
+                "device-hub-bundle",
+                "the selected Xcode does not contain the expected Device Hub"
+            )
+        }
+        let deviceHubExecutableURL = deviceHubURL
+            .appendingPathComponent("Contents/MacOS", isDirectory: true)
+            .appendingPathComponent(deviceHubExecutable)
+        guard fileManager.isExecutableFile(atPath: deviceHubExecutableURL.path) else {
+            throw CLIError.unavailable(
+                "device-hub-executable",
+                "missing executable at \(deviceHubExecutableURL.path)"
+            )
+        }
+
+        let deviceHubImplementationURL = deviceHubURL
+            .appendingPathComponent(ToolConstants.deviceHubImplementationPath)
+        guard fileManager.isExecutableFile(atPath: deviceHubImplementationURL.path) else {
+            throw CLIError.unavailable(
+                "device-hub-implementation",
+                "missing executable at \(deviceHubImplementationURL.path)"
+            )
+        }
+        let deviceHubBinary = try binaryData(
+            at: deviceHubImplementationURL,
+            identifier: "device-hub-implementation"
+        )
+        let deviceHubKeyData = Data(ToolConstants.deviceHubPreference.key.utf8)
+        guard deviceHubBinary.range(of: deviceHubKeyData) != nil else {
+            throw CLIError.unavailable(
+                "device-hub-preference-key",
+                "Device Hub in Xcode \(xcode.version) build \(xcode.buildVersion) no longer contains the verified preference key"
+            )
+        }
+
+        let binaryURL = xcode.applicationURL
+            .appendingPathComponent(ToolConstants.ideIOSSupportCorePath)
+        let binary = try binaryData(at: binaryURL, identifier: "xcode-probe-binary")
+        let keyData = Data(ToolConstants.xcodePreference.key.utf8)
+        guard binary.range(of: keyData) != nil else {
+            throw CLIError.unavailable(
+                "xcode-preference-key",
+                "Xcode \(xcode.version) build \(xcode.buildVersion) no longer contains the verified preference key"
+            )
+        }
+        return xcode
+    }
+
+    private func binaryData(at url: URL, identifier: String) throws -> Data {
+        guard fileManager.isReadableFile(atPath: url.path) else {
+            throw CLIError.unavailable(
+                identifier,
+                "missing readable binary at \(url.path)"
+            )
+        }
+        do {
+            return try Data(contentsOf: url, options: .mappedIfSafe)
+        } catch {
+            throw CLIError.io(
+                identifier,
+                "could not read \(url.path): \(error.localizedDescription)"
+            )
+        }
+    }
+
+    func legacySimulator(explicitXcodeURL: URL?) throws -> SimulatorInstallation {
+        if let explicitXcodeURL {
+            return try inspectLegacySimulator(in: explicitXcodeURL)
+        }
+
+        let candidates = legacySearchRoots.flatMap { root -> [SimulatorInstallation] in
+            guard let entries = try? fileManager.contentsOfDirectory(
+                at: root,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            ) else {
+                return []
+            }
+            return entries.compactMap { entry in
+                guard entry.pathExtension == "app",
+                      entry.lastPathComponent.hasPrefix("Xcode")
+                else {
+                    return nil
+                }
+                return try? inspectLegacySimulator(in: entry)
+            }
+        }
+
+        guard let selected = candidates.max(by: { lhs, rhs in
+            if lhs.xcode.version != rhs.xcode.version {
+                return lhs.xcode.version < rhs.xcode.version
+            }
+            return lhs.xcode.applicationURL.path < rhs.xcode.applicationURL.path
+        }) else {
+            throw CLIError.unavailable(
+                "legacy-simulator",
+                "no validated Xcode 26 Simulator was found; use --legacy-xcode <path>"
+            )
+        }
+        return selected
+    }
+
+    private func selectedDeveloperDirectory() throws -> URL {
+        if let path = environment["DEVELOPER_DIR"], !path.isEmpty {
+            return URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL
+        }
+
+        let output = try runner.run(executable: Self.xcodeSelect, arguments: ["-p"])
+        guard output.terminationStatus == 0, !output.stdoutText.isEmpty else {
+            let detail = output.stderrText.isEmpty
+                ? "exit status \(output.terminationStatus)"
+                : output.stderrText
+            throw CLIError.unavailable(
+                "selected-xcode",
+                "xcode-select could not resolve an Xcode: \(detail)"
+            )
+        }
+        return URL(fileURLWithPath: output.stdoutText, isDirectory: true).standardizedFileURL
+    }
+
+    private func xcodeApplicationURL(forDeveloperDirectory url: URL) throws -> URL {
+        guard url.lastPathComponent == "Developer" else {
+            throw CLIError.unavailable(
+                "developer-directory",
+                "DEVELOPER_DIR must end in Contents/Developer: \(url.path)"
+            )
+        }
+        let contentsURL = url.deletingLastPathComponent()
+        guard contentsURL.lastPathComponent == "Contents" else {
+            throw CLIError.unavailable(
+                "developer-directory",
+                "DEVELOPER_DIR must end in Contents/Developer: \(url.path)"
+            )
+        }
+        return contentsURL.deletingLastPathComponent().standardizedFileURL
+    }
+
+    private func inspectLegacySimulator(in xcodeURL: URL) throws -> SimulatorInstallation {
+        let xcode = try inspectXcode(at: xcodeURL.standardizedFileURL)
+        guard xcode.version.major == ToolConstants.legacyXcodeMajorVersion else {
+            throw CLIError.unavailable(
+                "legacy-xcode-version",
+                "legacy Simulator must come from Xcode 26, found Xcode \(xcode.version)"
+            )
+        }
+
+        let simulatorURL = xcode.applicationURL
+            .appendingPathComponent(ToolConstants.simulatorPath, isDirectory: true)
+        let info = try propertyList(at: simulatorURL.appendingPathComponent("Contents/Info.plist"))
+        guard info["CFBundleIdentifier"] as? String == ToolConstants.simulatorBundleIdentifier,
+              let executable = info["CFBundleExecutable"] as? String,
+              let version = info["CFBundleShortVersionString"] as? String,
+              let buildVersion = info["CFBundleVersion"] as? String
+        else {
+            throw CLIError.unavailable(
+                "legacy-simulator-bundle",
+                "\(simulatorURL.path) is not a valid Simulator application"
+            )
+        }
+
+        let executableURL = simulatorURL
+            .appendingPathComponent("Contents/MacOS")
+            .appendingPathComponent(executable)
+        guard fileManager.isExecutableFile(atPath: executableURL.path) else {
+            throw CLIError.unavailable(
+                "legacy-simulator-executable",
+                "missing executable at \(executableURL.path)"
+            )
+        }
+        try signatureValidator.validateAppleApplication(
+            simulatorURL,
+            ToolConstants.simulatorBundleIdentifier
+        )
+        return SimulatorInstallation(
+            applicationURL: simulatorURL,
+            xcode: xcode,
+            version: version,
+            buildVersion: buildVersion
+        )
+    }
+
+    private func inspectXcode(at applicationURL: URL) throws -> XcodeInstallation {
+        let info = try propertyList(
+            at: applicationURL.appendingPathComponent("Contents/Info.plist")
+        )
+        guard info["CFBundleIdentifier"] as? String == ToolConstants.xcodeBundleIdentifier,
+              let versionString = info["CFBundleShortVersionString"] as? String
+        else {
+            throw CLIError.unavailable(
+                "xcode-bundle",
+                "\(applicationURL.path) is not a valid Xcode application"
+            )
+        }
+        let version = try ToolVersion(versionString)
+
+        let versionInfo = try propertyList(
+            at: applicationURL.appendingPathComponent("Contents/version.plist")
+        )
+        guard let buildVersion = versionInfo["ProductBuildVersion"] as? String else {
+            throw CLIError.unavailable(
+                "xcode-build-version",
+                "\(applicationURL.path) has no ProductBuildVersion"
+            )
+        }
+        return XcodeInstallation(
+            applicationURL: applicationURL,
+            version: version,
+            buildVersion: buildVersion
+        )
+    }
+
+    private func propertyList(at url: URL) throws -> [String: Any] {
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            throw CLIError.unavailable(
+                "bundle-property-list",
+                "could not read \(url.path): \(error.localizedDescription)"
+            )
+        }
+
+        do {
+            let object = try PropertyListSerialization.propertyList(
+                from: data,
+                options: [],
+                format: nil
+            )
+            guard let dictionary = object as? [String: Any] else {
+                throw CLIError.configuration(
+                    "bundle-property-list",
+                    "\(url.path) is not a dictionary"
+                )
+            }
+            return dictionary
+        } catch let error as CLIError {
+            throw error
+        } catch {
+            throw CLIError.configuration(
+                "bundle-property-list",
+                "could not decode \(url.path): \(error.localizedDescription)"
+            )
+        }
+    }
+}

--- a/Sources/XcodeSimulatorHost/Installations/Installations.swift
+++ b/Sources/XcodeSimulatorHost/Installations/Installations.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct XcodeInstallation: Equatable {
+    let applicationURL: URL
+    let version: ToolVersion
+    let buildVersion: String
+}
+
+struct SimulatorInstallation: Equatable {
+    let applicationURL: URL
+    let xcode: XcodeInstallation
+    let version: String
+    let buildVersion: String
+}

--- a/Sources/XcodeSimulatorHost/Installations/ToolVersion.swift
+++ b/Sources/XcodeSimulatorHost/Installations/ToolVersion.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+struct ToolVersion: Comparable, Equatable, CustomStringConvertible {
+    let components: [Int]
+    let description: String
+
+    init(_ value: String) throws {
+        let numericPrefix = value.prefix { $0.isNumber || $0 == "." }
+        let parsed = numericPrefix.split(separator: ".", omittingEmptySubsequences: false)
+        guard !parsed.isEmpty,
+              parsed.allSatisfy({ !$0.isEmpty && Int($0) != nil })
+        else {
+            throw CLIError.configuration(
+                "version-format",
+                "invalid tool version '\(value)'"
+            )
+        }
+        components = parsed.compactMap { Int($0) }
+        description = value
+    }
+
+    var major: Int {
+        components[0]
+    }
+
+    static func == (lhs: ToolVersion, rhs: ToolVersion) -> Bool {
+        !((lhs < rhs) || (rhs < lhs))
+    }
+
+    static func < (lhs: ToolVersion, rhs: ToolVersion) -> Bool {
+        let count = max(lhs.components.count, rhs.components.count)
+        for index in 0..<count {
+            let left = index < lhs.components.count ? lhs.components[index] : 0
+            let right = index < rhs.components.count ? rhs.components[index] : 0
+            if left != right {
+                return left < right
+            }
+        }
+        return false
+    }
+}

--- a/Sources/XcodeSimulatorHost/Preferences/DefaultsStore.swift
+++ b/Sources/XcodeSimulatorHost/Preferences/DefaultsStore.swift
@@ -7,6 +7,12 @@ struct DefaultsStore {
         let observed: ManagedPreferenceState
     }
 
+    private struct MutationStep {
+        let preference: ManagedPreference
+        let value: StoredBoolean
+        let resultingState: ManagedPreferenceState
+    }
+
     private static let executable = URL(fileURLWithPath: "/usr/bin/defaults")
 
     private let runner: any CommandRunning
@@ -16,9 +22,16 @@ struct DefaultsStore {
     }
 
     func readState() throws -> ManagedPreferenceState {
-        ManagedPreferenceState(
-            xcodeSession: try read(ToolConstants.xcodePreference),
-            deviceHubAutoStartSuppression: try read(ToolConstants.deviceHubPreference)
+        let existingDomains = try existingDomains()
+        return ManagedPreferenceState(
+            xcodeSession: try read(
+                ToolConstants.xcodePreference,
+                existingDomains: existingDomains
+            ),
+            deviceHubAutoStartSuppression: try read(
+                ToolConstants.deviceHubPreference,
+                existingDomains: existingDomains
+            )
         )
     }
 
@@ -66,25 +79,56 @@ struct DefaultsStore {
                 observed: current
             )
         }
-        var didChange = false
 
-        if current.xcodeSession != target.xcodeSession {
-            try write(target.xcodeSession, to: ToolConstants.xcodePreference)
-            didChange = true
-        }
-        if current.deviceHubAutoStartSuppression != target.deviceHubAutoStartSuppression {
-            try write(target.deviceHubAutoStartSuppression, to: ToolConstants.deviceHubPreference)
-            didChange = true
+        let steps = mutationSteps(from: current, to: target)
+        var expected = current
+        for step in steps {
+            let observed = try readState()
+            guard observed == expected else {
+                throw StateMismatch(expected: [expected], observed: observed)
+            }
+            try write(step.value, to: step.preference)
+            expected = step.resultingState
         }
 
         let observed = try readState()
         guard observed == target else {
-            throw CLIError.io(
-                "preference-verification",
-                "expected \(target), observed \(observed)"
+            throw StateMismatch(expected: [target], observed: observed)
+        }
+        return !steps.isEmpty
+    }
+
+    private func mutationSteps(
+        from current: ManagedPreferenceState,
+        to target: ManagedPreferenceState
+    ) -> [MutationStep] {
+        var state = current
+        var steps: [MutationStep] = []
+
+        if state.xcodeSession != target.xcodeSession {
+            state = stateAfterXcodePreference(from: state, to: target)
+            steps.append(
+                MutationStep(
+                    preference: ToolConstants.xcodePreference,
+                    value: target.xcodeSession,
+                    resultingState: state
+                )
             )
         }
-        return didChange
+        if state.deviceHubAutoStartSuppression != target.deviceHubAutoStartSuppression {
+            state = ManagedPreferenceState(
+                xcodeSession: state.xcodeSession,
+                deviceHubAutoStartSuppression: target.deviceHubAutoStartSuppression
+            )
+            steps.append(
+                MutationStep(
+                    preference: ToolConstants.deviceHubPreference,
+                    value: target.deviceHubAutoStartSuppression,
+                    resultingState: state
+                )
+            )
+        }
+        return steps
     }
 
     private func stateAfterXcodePreference(
@@ -97,15 +141,19 @@ struct DefaultsStore {
         )
     }
 
-    private func read(_ preference: ManagedPreference) throws -> StoredBoolean {
+    private func read(
+        _ preference: ManagedPreference,
+        existingDomains: Set<String>
+    ) throws -> StoredBoolean {
+        guard existingDomains.contains(preference.domain) else {
+            return .absent
+        }
+
         let output = try runner.run(
             executable: Self.executable,
             arguments: ["export", preference.domain, "-"]
         )
         guard output.terminationStatus == 0 else {
-            if try !domainExists(preference.domain) {
-                return .absent
-            }
             throw commandFailure(
                 identifier: "preference-read",
                 action: "read \(preference.domain).\(preference.key)",
@@ -148,7 +196,7 @@ struct DefaultsStore {
         return StoredBoolean(number.boolValue)
     }
 
-    private func domainExists(_ domain: String) throws -> Bool {
+    private func existingDomains() throws -> Set<String> {
         let output = try runner.run(
             executable: Self.executable,
             arguments: ["domains"]
@@ -161,11 +209,14 @@ struct DefaultsStore {
             )
         }
 
-        return output.stdoutText
-            .split(separator: ",")
-            .contains { candidate in
-                candidate.trimmingCharacters(in: .whitespacesAndNewlines) == domain
-            }
+        return Set(
+            output.stdoutText
+                .split(separator: ",")
+                .map { candidate in
+                    candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+                .filter { !$0.isEmpty }
+        )
     }
 
     private func write(_ value: StoredBoolean, to preference: ManagedPreference) throws {

--- a/Sources/XcodeSimulatorHost/Preferences/DefaultsStore.swift
+++ b/Sources/XcodeSimulatorHost/Preferences/DefaultsStore.swift
@@ -103,6 +103,9 @@ struct DefaultsStore {
             arguments: ["export", preference.domain, "-"]
         )
         guard output.terminationStatus == 0 else {
+            if try !domainExists(preference.domain) {
+                return .absent
+            }
             throw commandFailure(
                 identifier: "preference-read",
                 action: "read \(preference.domain).\(preference.key)",
@@ -143,6 +146,26 @@ struct DefaultsStore {
             )
         }
         return StoredBoolean(number.boolValue)
+    }
+
+    private func domainExists(_ domain: String) throws -> Bool {
+        let output = try runner.run(
+            executable: Self.executable,
+            arguments: ["domains"]
+        )
+        guard output.terminationStatus == 0 else {
+            throw commandFailure(
+                identifier: "preference-read",
+                action: "list preference domains",
+                output: output
+            )
+        }
+
+        return output.stdoutText
+            .split(separator: ",")
+            .contains { candidate in
+                candidate.trimmingCharacters(in: .whitespacesAndNewlines) == domain
+            }
     }
 
     private func write(_ value: StoredBoolean, to preference: ManagedPreference) throws {

--- a/Sources/XcodeSimulatorHost/Preferences/DefaultsStore.swift
+++ b/Sources/XcodeSimulatorHost/Preferences/DefaultsStore.swift
@@ -1,0 +1,179 @@
+import CoreFoundation
+import Foundation
+
+struct DefaultsStore {
+    struct StateMismatch: Error, Equatable {
+        let expected: [ManagedPreferenceState]
+        let observed: ManagedPreferenceState
+    }
+
+    private static let executable = URL(fileURLWithPath: "/usr/bin/defaults")
+
+    private let runner: any CommandRunning
+
+    init(runner: any CommandRunning) {
+        self.runner = runner
+    }
+
+    func readState() throws -> ManagedPreferenceState {
+        ManagedPreferenceState(
+            xcodeSession: try read(ToolConstants.xcodePreference),
+            deviceHubAutoStartSuppression: try read(ToolConstants.deviceHubPreference)
+        )
+    }
+
+    @discardableResult
+    func apply(
+        _ target: ManagedPreferenceState,
+        from expected: ManagedPreferenceState
+    ) throws -> Bool {
+        try apply(target, allowedCurrentStates: [expected])
+    }
+
+    func rollback(
+        to before: ManagedPreferenceState,
+        fromAttemptedTarget target: ManagedPreferenceState
+    ) throws -> Bool {
+        return try apply(
+            before,
+            allowedCurrentStates: [
+                before,
+                stateAfterXcodePreference(from: before, to: target),
+                target,
+            ]
+        )
+    }
+
+    func isAmbiguousIntermediate(
+        _ observed: ManagedPreferenceState,
+        from before: ManagedPreferenceState,
+        to target: ManagedPreferenceState
+    ) -> Bool {
+        let intermediate = stateAfterXcodePreference(from: before, to: target)
+        return intermediate != before
+            && intermediate != target
+            && observed == intermediate
+    }
+
+    private func apply(
+        _ target: ManagedPreferenceState,
+        allowedCurrentStates: [ManagedPreferenceState]
+    ) throws -> Bool {
+        let current = try readState()
+        guard allowedCurrentStates.contains(current) else {
+            throw StateMismatch(
+                expected: allowedCurrentStates,
+                observed: current
+            )
+        }
+        var didChange = false
+
+        if current.xcodeSession != target.xcodeSession {
+            try write(target.xcodeSession, to: ToolConstants.xcodePreference)
+            didChange = true
+        }
+        if current.deviceHubAutoStartSuppression != target.deviceHubAutoStartSuppression {
+            try write(target.deviceHubAutoStartSuppression, to: ToolConstants.deviceHubPreference)
+            didChange = true
+        }
+
+        let observed = try readState()
+        guard observed == target else {
+            throw CLIError.io(
+                "preference-verification",
+                "expected \(target), observed \(observed)"
+            )
+        }
+        return didChange
+    }
+
+    private func stateAfterXcodePreference(
+        from before: ManagedPreferenceState,
+        to target: ManagedPreferenceState
+    ) -> ManagedPreferenceState {
+        ManagedPreferenceState(
+            xcodeSession: target.xcodeSession,
+            deviceHubAutoStartSuppression: before.deviceHubAutoStartSuppression
+        )
+    }
+
+    private func read(_ preference: ManagedPreference) throws -> StoredBoolean {
+        let output = try runner.run(
+            executable: Self.executable,
+            arguments: ["export", preference.domain, "-"]
+        )
+        guard output.terminationStatus == 0 else {
+            throw commandFailure(
+                identifier: "preference-read",
+                action: "read \(preference.domain).\(preference.key)",
+                output: output
+            )
+        }
+
+        let object: Any
+        do {
+            object = try PropertyListSerialization.propertyList(
+                from: output.stdout,
+                options: [],
+                format: nil
+            )
+        } catch {
+            throw CLIError.io(
+                "preference-decode",
+                "could not decode \(preference.domain): \(error.localizedDescription)"
+            )
+        }
+        guard let domain = object as? [String: Any] else {
+            throw CLIError.configuration(
+                "preference-domain-type",
+                "\(preference.domain) is not a property-list dictionary"
+            )
+        }
+        guard let rawValue = domain[preference.key] else {
+            return .absent
+        }
+
+        let valueObject = rawValue as AnyObject
+        guard CFGetTypeID(valueObject) == CFBooleanGetTypeID(),
+              let number = valueObject as? NSNumber
+        else {
+            throw CLIError.configuration(
+                "preference-value-type",
+                "\(preference.domain).\(preference.key) is not Boolean"
+            )
+        }
+        return StoredBoolean(number.boolValue)
+    }
+
+    private func write(_ value: StoredBoolean, to preference: ManagedPreference) throws {
+        let arguments: [String]
+        switch value {
+        case .absent:
+            arguments = ["delete", preference.domain, preference.key]
+        case .falseValue:
+            arguments = ["write", preference.domain, preference.key, "-bool", "false"]
+        case .trueValue:
+            arguments = ["write", preference.domain, preference.key, "-bool", "true"]
+        }
+
+        let output = try runner.run(executable: Self.executable, arguments: arguments)
+        guard output.terminationStatus == 0 else {
+            throw commandFailure(
+                identifier: "preference-write",
+                action: "write \(preference.domain).\(preference.key)",
+                output: output
+            )
+        }
+    }
+
+    private func commandFailure(
+        identifier: String,
+        action: String,
+        output: CommandOutput
+    ) -> CLIError {
+        let detail = output.stderrText.isEmpty
+            ? "exit status \(output.terminationStatus)"
+            : output.stderrText
+        return CLIError.io(identifier, "could not \(action): \(detail)")
+    }
+}

--- a/Sources/XcodeSimulatorHost/Preferences/ManagedPreferences.swift
+++ b/Sources/XcodeSimulatorHost/Preferences/ManagedPreferences.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+struct ManagedPreference: Equatable, Hashable {
+    let domain: String
+    let key: String
+}
+
+enum StoredBoolean: String, Codable, Equatable, CustomStringConvertible {
+    case absent
+    case falseValue = "false"
+    case trueValue = "true"
+
+    init(_ value: Bool) {
+        self = value ? .trueValue : .falseValue
+    }
+
+    var booleanValue: Bool? {
+        switch self {
+        case .absent:
+            nil
+        case .falseValue:
+            false
+        case .trueValue:
+            true
+        }
+    }
+
+    var description: String {
+        rawValue
+    }
+}
+
+struct ManagedPreferenceState: Codable, Equatable, CustomStringConvertible {
+    let xcodeSession: StoredBoolean
+    let deviceHubAutoStartSuppression: StoredBoolean
+
+    static let deviceHub = ManagedPreferenceState(
+        xcodeSession: .absent,
+        deviceHubAutoStartSuppression: .absent
+    )
+
+    static let legacy = ManagedPreferenceState(
+        xcodeSession: .trueValue,
+        deviceHubAutoStartSuppression: .trueValue
+    )
+
+    var effectiveMode: HostMode {
+        xcodeSession == .trueValue ? .legacy : .deviceHub
+    }
+
+    var description: String {
+        "Xcode=\(xcodeSession), DeviceHubAutoStartSuppression=\(deviceHubAutoStartSuppression)"
+    }
+}
+
+enum HostMode: String, Codable, Equatable {
+    case legacy
+    case deviceHub = "device-hub"
+
+    var targetState: ManagedPreferenceState {
+        switch self {
+        case .legacy:
+            .legacy
+        case .deviceHub:
+            .deviceHub
+        }
+    }
+}

--- a/Sources/XcodeSimulatorHost/State/ReceiptStore.swift
+++ b/Sources/XcodeSimulatorHost/State/ReceiptStore.swift
@@ -107,6 +107,23 @@ struct ReceiptStore {
     }
 
     func withExclusiveLock<T>(_ body: () throws -> T) throws -> T {
+        let descriptor = try acquireExclusiveLock()
+        defer {
+            releaseExclusiveLock(descriptor)
+        }
+        return try body()
+    }
+
+    nonisolated(nonsending)
+    func withExclusiveLock<T>(_ body: () async throws -> T) async throws -> T {
+        let descriptor = try acquireExclusiveLock()
+        defer {
+            releaseExclusiveLock(descriptor)
+        }
+        return try await body()
+    }
+
+    private func acquireExclusiveLock() throws -> Int32 {
         try createDirectoryIfNeeded()
 
         let descriptor = Darwin.open(
@@ -120,41 +137,44 @@ struct ReceiptStore {
                 "could not open \(lockURL.path): \(String(cString: strerror(errno)))"
             )
         }
-        defer {
-            Darwin.close(descriptor)
-        }
 
-        var metadata = stat()
-        guard Darwin.fstat(descriptor, &metadata) == 0 else {
-            throw CLIError.io(
-                "operation-lock",
-                "could not inspect \(lockURL.path): \(String(cString: strerror(errno)))"
-            )
-        }
-        guard metadata.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG) else {
-            throw CLIError.configuration(
-                "operation-lock",
-                "operation lock is not a regular file: \(lockURL.path)"
-            )
-        }
-
-        guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
-            if errno == EWOULDBLOCK || errno == EAGAIN {
-                throw CLIError.temporary(
+        do {
+            var metadata = stat()
+            guard Darwin.fstat(descriptor, &metadata) == 0 else {
+                throw CLIError.io(
                     "operation-lock",
-                    "another \(ToolConstants.name) operation is in progress"
+                    "could not inspect \(lockURL.path): \(String(cString: strerror(errno)))"
                 )
             }
-            throw CLIError.io(
-                "operation-lock",
-                "could not lock \(lockURL.path): \(String(cString: strerror(errno)))"
-            )
-        }
-        defer {
-            _ = flock(descriptor, LOCK_UN)
-        }
+            guard metadata.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG) else {
+                throw CLIError.configuration(
+                    "operation-lock",
+                    "operation lock is not a regular file: \(lockURL.path)"
+                )
+            }
 
-        return try body()
+            guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
+                if errno == EWOULDBLOCK || errno == EAGAIN {
+                    throw CLIError.temporary(
+                        "operation-lock",
+                        "another \(ToolConstants.name) operation is in progress"
+                    )
+                }
+                throw CLIError.io(
+                    "operation-lock",
+                    "could not lock \(lockURL.path): \(String(cString: strerror(errno)))"
+                )
+            }
+            return descriptor
+        } catch {
+            Darwin.close(descriptor)
+            throw error
+        }
+    }
+
+    private func releaseExclusiveLock(_ descriptor: Int32) {
+        _ = flock(descriptor, LOCK_UN)
+        Darwin.close(descriptor)
     }
 
     private func createDirectoryIfNeeded() throws {

--- a/Sources/XcodeSimulatorHost/State/ReceiptStore.swift
+++ b/Sources/XcodeSimulatorHost/State/ReceiptStore.swift
@@ -1,0 +1,195 @@
+import Darwin
+import Foundation
+
+struct ReceiptStore {
+    let directoryURL: URL
+    let receiptURL: URL
+    let lockURL: URL
+
+    private let fileManager: FileManager
+
+    init(directoryURL: URL? = nil, fileManager: FileManager = .default) throws {
+        self.fileManager = fileManager
+
+        let resolvedDirectory: URL
+        if let directoryURL {
+            resolvedDirectory = directoryURL
+        } else {
+            guard let applicationSupport = fileManager.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            ).first else {
+                throw CLIError.cannotCreate(
+                    "application-support",
+                    "could not resolve the user Application Support directory"
+                )
+            }
+            resolvedDirectory = applicationSupport
+                .appendingPathComponent(ToolConstants.name, isDirectory: true)
+        }
+
+        self.directoryURL = resolvedDirectory.standardizedFileURL
+        receiptURL = self.directoryURL.appendingPathComponent("state.plist")
+        lockURL = self.directoryURL.appendingPathComponent("state.lock")
+    }
+
+    func load() throws -> RestorationReceipt? {
+        guard fileManager.fileExists(atPath: receiptURL.path) else {
+            return nil
+        }
+
+        let data: Data
+        do {
+            data = try Data(contentsOf: receiptURL)
+        } catch {
+            throw CLIError.io(
+                "receipt-read",
+                "could not read \(receiptURL.path): \(error.localizedDescription)"
+            )
+        }
+
+        do {
+            let receipt = try PropertyListDecoder().decode(RestorationReceipt.self, from: data)
+            try receipt.validate()
+            return receipt
+        } catch let error as CLIError {
+            throw error
+        } catch {
+            throw CLIError.configuration(
+                "receipt-decode",
+                "could not decode \(receiptURL.path): \(error.localizedDescription)"
+            )
+        }
+    }
+
+    func save(_ receipt: RestorationReceipt) throws {
+        try receipt.validate()
+        try createDirectoryIfNeeded()
+
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+        let data: Data
+        do {
+            data = try encoder.encode(receipt)
+        } catch {
+            throw CLIError.software(
+                "receipt-encode",
+                "could not encode restoration receipt: \(error.localizedDescription)"
+            )
+        }
+
+        do {
+            try data.write(to: receiptURL, options: .atomic)
+            try fileManager.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: receiptURL.path
+            )
+        } catch {
+            throw CLIError.io(
+                "receipt-write",
+                "could not write \(receiptURL.path): \(error.localizedDescription)"
+            )
+        }
+    }
+
+    func deleteReceipt() throws {
+        guard fileManager.fileExists(atPath: receiptURL.path) else {
+            return
+        }
+        do {
+            try fileManager.removeItem(at: receiptURL)
+        } catch {
+            throw CLIError.io(
+                "receipt-delete",
+                "could not remove \(receiptURL.path): \(error.localizedDescription)"
+            )
+        }
+    }
+
+    func withExclusiveLock<T>(_ body: () throws -> T) throws -> T {
+        try createDirectoryIfNeeded()
+
+        let descriptor = Darwin.open(
+            lockURL.path,
+            O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW | O_NONBLOCK,
+            mode_t(0o600)
+        )
+        guard descriptor >= 0 else {
+            throw CLIError.cannotCreate(
+                "operation-lock",
+                "could not open \(lockURL.path): \(String(cString: strerror(errno)))"
+            )
+        }
+        defer {
+            Darwin.close(descriptor)
+        }
+
+        var metadata = stat()
+        guard Darwin.fstat(descriptor, &metadata) == 0 else {
+            throw CLIError.io(
+                "operation-lock",
+                "could not inspect \(lockURL.path): \(String(cString: strerror(errno)))"
+            )
+        }
+        guard metadata.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG) else {
+            throw CLIError.configuration(
+                "operation-lock",
+                "operation lock is not a regular file: \(lockURL.path)"
+            )
+        }
+
+        guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
+            if errno == EWOULDBLOCK || errno == EAGAIN {
+                throw CLIError.temporary(
+                    "operation-lock",
+                    "another \(ToolConstants.name) operation is in progress"
+                )
+            }
+            throw CLIError.io(
+                "operation-lock",
+                "could not lock \(lockURL.path): \(String(cString: strerror(errno)))"
+            )
+        }
+        defer {
+            _ = flock(descriptor, LOCK_UN)
+        }
+
+        return try body()
+    }
+
+    private func createDirectoryIfNeeded() throws {
+        do {
+            if !fileManager.fileExists(atPath: directoryURL.path) {
+                try fileManager.createDirectory(
+                    at: directoryURL,
+                    withIntermediateDirectories: true,
+                    attributes: [.posixPermissions: 0o700]
+                )
+            }
+            var metadata = stat()
+            guard Darwin.lstat(directoryURL.path, &metadata) == 0 else {
+                throw CLIError.cannotCreate(
+                    "state-directory",
+                    "could not inspect \(directoryURL.path): \(String(cString: strerror(errno)))"
+                )
+            }
+            guard metadata.st_mode & mode_t(S_IFMT) == mode_t(S_IFDIR) else {
+                throw CLIError.configuration(
+                    "state-directory",
+                    "state path is not a real directory: \(directoryURL.path)"
+                )
+            }
+            try fileManager.setAttributes(
+                [.posixPermissions: 0o700],
+                ofItemAtPath: directoryURL.path
+            )
+        } catch let error as CLIError {
+            throw error
+        } catch {
+            throw CLIError.cannotCreate(
+                "state-directory",
+                "could not prepare \(directoryURL.path): \(error.localizedDescription)"
+            )
+        }
+    }
+}

--- a/Sources/XcodeSimulatorHost/State/ReceiptStore.swift
+++ b/Sources/XcodeSimulatorHost/State/ReceiptStore.swift
@@ -107,7 +107,7 @@ struct ReceiptStore {
     }
 
     func withExclusiveLock<T>(_ body: () throws -> T) throws -> T {
-        let descriptor = try acquireExclusiveLock()
+        let descriptor = try acquireExclusiveLock(createIfNeeded: true)
         defer {
             releaseExclusiveLock(descriptor)
         }
@@ -116,22 +116,68 @@ struct ReceiptStore {
 
     nonisolated(nonsending)
     func withExclusiveLock<T>(_ body: () async throws -> T) async throws -> T {
-        let descriptor = try acquireExclusiveLock()
+        let descriptor = try acquireExclusiveLock(createIfNeeded: true)
         defer {
             releaseExclusiveLock(descriptor)
         }
         return try await body()
     }
 
-    private func acquireExclusiveLock() throws -> Int32 {
-        try createDirectoryIfNeeded()
+    func withExistingExclusiveLock<T>(_ body: () throws -> T) throws -> T {
+        let descriptor = try acquireExclusiveLock(createIfNeeded: false)
+        defer {
+            releaseExclusiveLock(descriptor)
+        }
+        return try body()
+    }
+
+    func stateDirectoryExists() throws -> Bool {
+        var metadata = stat()
+        guard Darwin.lstat(directoryURL.path, &metadata) == 0 else {
+            if errno == ENOENT {
+                return false
+            }
+            throw CLIError.io(
+                "state-directory",
+                "could not inspect \(directoryURL.path): \(String(cString: strerror(errno)))"
+            )
+        }
+        guard metadata.st_mode & mode_t(S_IFMT) == mode_t(S_IFDIR) else {
+            throw CLIError.configuration(
+                "state-directory",
+                "state path is not a real directory: \(directoryURL.path)"
+            )
+        }
+        return true
+    }
+
+    private func acquireExclusiveLock(createIfNeeded: Bool) throws -> Int32 {
+        if createIfNeeded {
+            try createDirectoryIfNeeded()
+        } else if try !stateDirectoryExists() {
+            throw CLIError.temporary(
+                "operation-lock",
+                "state changed while a read-only snapshot was being prepared; retry"
+            )
+        }
+
+        var openFlags = O_RDWR | O_CLOEXEC | O_NOFOLLOW | O_NONBLOCK
+        if createIfNeeded {
+            openFlags |= O_CREAT
+        }
 
         let descriptor = Darwin.open(
             lockURL.path,
-            O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW | O_NONBLOCK,
+            openFlags,
             mode_t(0o600)
         )
         guard descriptor >= 0 else {
+            if !createIfNeeded, errno == ENOENT {
+                throw CLIError.temporary(
+                    "operation-lock",
+                    "state directory exists without its operation lock; retry"
+                )
+            }
             throw CLIError.cannotCreate(
                 "operation-lock",
                 "could not open \(lockURL.path): \(String(cString: strerror(errno)))"

--- a/Sources/XcodeSimulatorHost/State/RestorationReceipt.swift
+++ b/Sources/XcodeSimulatorHost/State/RestorationReceipt.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+struct PendingMutation: Codable, Equatable {
+    let before: ManagedPreferenceState
+    let target: ManagedPreferenceState
+}
+
+struct RestorationReceipt: Codable, Equatable {
+    static let currentSchemaVersion = 1
+
+    let schemaVersion: Int
+    let toolIdentifier: String
+    let capturedAt: Date
+    let xcodeVersionAtCapture: String
+    let xcodeBuildAtCapture: String
+    let original: ManagedPreferenceState
+    var expectedCurrent: ManagedPreferenceState
+    var pending: PendingMutation?
+
+    init(
+        capturedAt: Date,
+        xcode: XcodeInstallation,
+        original: ManagedPreferenceState
+    ) {
+        schemaVersion = Self.currentSchemaVersion
+        toolIdentifier = ToolConstants.name
+        self.capturedAt = capturedAt
+        xcodeVersionAtCapture = xcode.version.description
+        xcodeBuildAtCapture = xcode.buildVersion
+        self.original = original
+        expectedCurrent = original
+        pending = nil
+    }
+
+    func validate() throws {
+        guard schemaVersion == Self.currentSchemaVersion else {
+            throw CLIError.configuration(
+                "receipt-schema",
+                "unsupported receipt schema \(schemaVersion)"
+            )
+        }
+        guard toolIdentifier == ToolConstants.name else {
+            throw CLIError.configuration(
+                "receipt-owner",
+                "receipt belongs to '\(toolIdentifier)', not \(ToolConstants.name)"
+            )
+        }
+        if let pending {
+            guard pending.before == expectedCurrent else {
+                throw CLIError.configuration(
+                    "receipt-pending-before",
+                    "pending mutation starts at \(pending.before), but the receipt expects \(expectedCurrent)"
+                )
+            }
+            guard pending.before != pending.target else {
+                throw CLIError.configuration(
+                    "receipt-pending-noop",
+                    "pending mutation has identical before and target states"
+                )
+            }
+        }
+    }
+}

--- a/Sources/XcodeSimulatorHost/System/CodeSignatureValidator.swift
+++ b/Sources/XcodeSimulatorHost/System/CodeSignatureValidator.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Security
+
+struct CodeSignatureValidator: Sendable {
+    let validateAppleApplication: @Sendable (URL, String) throws -> Void
+
+    static let live = CodeSignatureValidator { applicationURL, bundleIdentifier in
+        var staticCode: SecStaticCode?
+        let createStatus = SecStaticCodeCreateWithPath(
+            applicationURL as CFURL,
+            SecCSFlags(),
+            &staticCode
+        )
+        guard createStatus == errSecSuccess, let staticCode else {
+            throw CLIError.unavailable(
+                "code-signature",
+                "could not inspect the signature of \(applicationURL.path): \(securityMessage(createStatus))"
+            )
+        }
+
+        var requirement: SecRequirement?
+        let requirementText = "identifier \"\(bundleIdentifier)\" and anchor apple" as CFString
+        let requirementStatus = SecRequirementCreateWithString(
+            requirementText,
+            SecCSFlags(),
+            &requirement
+        )
+        guard requirementStatus == errSecSuccess, let requirement else {
+            throw CLIError.software(
+                "code-requirement",
+                "could not create the Apple code requirement: \(securityMessage(requirementStatus))"
+            )
+        }
+
+        let flags = SecCSFlags(
+            rawValue: kSecCSCheckAllArchitectures
+                | kSecCSStrictValidate
+                | kSecCSRestrictSymlinks
+                | kSecCSRestrictToAppLike
+        )
+        let validationStatus = SecStaticCodeCheckValidity(
+            staticCode,
+            flags,
+            requirement
+        )
+        guard validationStatus == errSecSuccess else {
+            throw CLIError.unavailable(
+                "code-signature",
+                "\(applicationURL.path) is not an intact Apple-signed \(bundleIdentifier) application: \(securityMessage(validationStatus))"
+            )
+        }
+    }
+}
+
+private func securityMessage(_ status: OSStatus) -> String {
+    if let message = SecCopyErrorMessageString(status, nil) {
+        return message as String
+    }
+    return "OSStatus \(status)"
+}

--- a/Sources/XcodeSimulatorHost/System/SystemCommandRunner.swift
+++ b/Sources/XcodeSimulatorHost/System/SystemCommandRunner.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+struct CommandOutput: Equatable {
+    let terminationStatus: Int32
+    let stdout: Data
+    let stderr: Data
+
+    var stdoutText: String {
+        String(decoding: stdout, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var stderrText: String {
+        String(decoding: stderr, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+protocol CommandRunning {
+    func run(executable: URL, arguments: [String]) throws -> CommandOutput
+}
+
+struct SystemCommandRunner: CommandRunning {
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    func run(executable: URL, arguments: [String]) throws -> CommandOutput {
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("\(ToolConstants.name)-\(UUID().uuidString)", isDirectory: true)
+
+        do {
+            try fileManager.createDirectory(
+                at: directory,
+                withIntermediateDirectories: false,
+                attributes: [.posixPermissions: 0o700]
+            )
+        } catch {
+            throw CLIError.cannotCreate(
+                "temporary-directory",
+                "could not create command output directory: \(error.localizedDescription)"
+            )
+        }
+        defer {
+            try? fileManager.removeItem(at: directory)
+        }
+
+        let stdoutURL = directory.appendingPathComponent("stdout")
+        let stderrURL = directory.appendingPathComponent("stderr")
+        guard fileManager.createFile(
+            atPath: stdoutURL.path,
+            contents: nil,
+            attributes: [.posixPermissions: 0o600]
+        ), fileManager.createFile(
+            atPath: stderrURL.path,
+            contents: nil,
+            attributes: [.posixPermissions: 0o600]
+        ) else {
+            throw CLIError.cannotCreate(
+                "temporary-output",
+                "could not create command output files"
+            )
+        }
+
+        let stdoutHandle: FileHandle
+        let stderrHandle: FileHandle
+        do {
+            stdoutHandle = try FileHandle(forWritingTo: stdoutURL)
+            stderrHandle = try FileHandle(forWritingTo: stderrURL)
+        } catch {
+            throw CLIError.io(
+                "temporary-output",
+                "could not open command output files: \(error.localizedDescription)"
+            )
+        }
+
+        var handlesAreOpen = true
+        defer {
+            if handlesAreOpen {
+                try? stdoutHandle.close()
+                try? stderrHandle.close()
+            }
+        }
+
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = arguments
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = stdoutHandle
+        process.standardError = stderrHandle
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            try stdoutHandle.close()
+            try stderrHandle.close()
+            handlesAreOpen = false
+        } catch {
+            throw CLIError.io(
+                "command-execution",
+                "could not run \(executable.path): \(error.localizedDescription)"
+            )
+        }
+
+        do {
+            return CommandOutput(
+                terminationStatus: process.terminationStatus,
+                stdout: try Data(contentsOf: stdoutURL),
+                stderr: try Data(contentsOf: stderrURL)
+            )
+        } catch {
+            throw CLIError.io(
+                "command-output",
+                "could not read output from \(executable.path): \(error.localizedDescription)"
+            )
+        }
+    }
+}

--- a/Sources/XcodeSimulatorHost/System/WorkspaceClient.swift
+++ b/Sources/XcodeSimulatorHost/System/WorkspaceClient.swift
@@ -7,8 +7,132 @@ struct RunningApplication: Equatable {
 }
 
 @MainActor
+private final class ApplicationTerminationWaiter {
+    private let application: NSRunningApplication
+    private let timeoutInterval: TimeInterval
+    private var observation: NSKeyValueObservation?
+    private var continuation: CheckedContinuation<Void, any Error>?
+    private var cancellationRequested = false
+    private var timeoutTimer: Timer?
+
+    init(
+        application: NSRunningApplication,
+        timeoutInterval: TimeInterval
+    ) {
+        self.application = application
+        self.timeoutInterval = timeoutInterval
+    }
+
+    func terminate() async throws {
+        guard !application.isTerminated else {
+            return
+        }
+
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                self.continuation = continuation
+                if cancellationRequested {
+                    finish(.failure(CancellationError()))
+                    return
+                }
+
+                // terminate() only confirms request delivery; isTerminated is the
+                // documented terminal state and remains valid for normal GUI exits.
+                observation = application.observe(
+                    \.isTerminated,
+                    options: [.new]
+                ) { [weak self] application, _ in
+                    guard application.isTerminated else {
+                        return
+                    }
+                    Task { @MainActor in
+                        self?.finish(.success(()))
+                    }
+                }
+                let timeoutTimer = Timer(
+                    timeInterval: timeoutInterval,
+                    repeats: false
+                ) { [weak self] _ in
+                    Task { @MainActor in
+                        guard let self else {
+                            return
+                        }
+                        self.finish(
+                            .failure(
+                                CLIError.temporary(
+                                    "device-hub-termination-timeout",
+                                    "Device Hub pid \(self.application.processIdentifier) did not finish terminating before the operation deadline"
+                                )
+                            )
+                        )
+                    }
+                }
+                self.timeoutTimer = timeoutTimer
+                RunLoop.main.add(timeoutTimer, forMode: .common)
+
+                if application.isTerminated {
+                    finish(.success(()))
+                    return
+                }
+
+                if !application.terminate() {
+                    RunLoop.main.perform(inModes: [.common]) { [weak self] in
+                        Task { @MainActor in
+                            guard let self else {
+                                return
+                            }
+                            let isStillRunning = NSRunningApplication.runningApplications(
+                                withBundleIdentifier: ToolConstants.deviceHubBundleIdentifier
+                            ).contains {
+                                // Do not compare PIDs: AppKit documents that an
+                                // NSRunningApplication PID may change.
+                                $0.isEqual(self.application) && !$0.isTerminated
+                            }
+                            if isStillRunning {
+                                self.finish(
+                                    .failure(
+                                        CLIError.temporary(
+                                            "device-hub-termination",
+                                            "Device Hub pid \(self.application.processIdentifier) did not accept a normal termination request"
+                                        )
+                                    )
+                                )
+                            } else {
+                                self.finish(.success(()))
+                            }
+                        }
+                    }
+                }
+            }
+        } onCancel: { [weak self] in
+            Task { @MainActor in
+                self?.cancel()
+            }
+        }
+    }
+
+    private func cancel() {
+        cancellationRequested = true
+        finish(.failure(CancellationError()))
+    }
+
+    private func finish(_ result: Result<Void, any Error>) {
+        guard let continuation else {
+            return
+        }
+        observation?.invalidate()
+        timeoutTimer?.invalidate()
+        timeoutTimer = nil
+        self.observation = nil
+        self.continuation = nil
+        continuation.resume(with: result)
+    }
+}
+
+@MainActor
 struct WorkspaceClient {
     var runningXcodes: () -> [RunningApplication]
+    var terminateDeviceHubs: (URL) async throws -> Int
     var openApplication: (URL) async throws -> URL
 
     static let live = WorkspaceClient(
@@ -20,6 +144,60 @@ struct WorkspaceClient {
                     processIdentifier: $0.processIdentifier,
                     bundleURL: $0.bundleURL
                 )
+            }
+        },
+        terminateDeviceHubs: { expectedApplicationURL in
+            let expected = expectedApplicationURL
+                .resolvingSymlinksInPath()
+                .standardizedFileURL
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: .seconds(10))
+            var terminatedCount = 0
+
+            while true {
+                let applications = NSRunningApplication.runningApplications(
+                    withBundleIdentifier: ToolConstants.deviceHubBundleIdentifier
+                ).filter { !$0.isTerminated }
+                guard !applications.isEmpty else {
+                    return terminatedCount
+                }
+
+                for application in applications {
+                    guard let bundleURL = application.bundleURL else {
+                        throw CLIError.configuration(
+                            "device-hub-identity",
+                            "refusing to terminate Device Hub pid \(application.processIdentifier) because it has no bundle URL"
+                        )
+                    }
+                    let observed = bundleURL
+                        .resolvingSymlinksInPath()
+                        .standardizedFileURL
+                    guard observed == expected else {
+                        throw CLIError.configuration(
+                            "device-hub-substitution",
+                            "refusing to terminate Device Hub pid \(application.processIdentifier) from \(observed.path); expected \(expected.path)"
+                        )
+                    }
+                }
+
+                for application in applications {
+                    let remaining = clock.now.duration(to: deadline)
+                    guard remaining > .zero else {
+                        throw CLIError.temporary(
+                            "device-hub-termination-timeout",
+                            "Device Hub kept running or relaunching for 10 seconds"
+                        )
+                    }
+                    let components = remaining.components
+                    let timeoutInterval = TimeInterval(components.seconds)
+                        + TimeInterval(components.attoseconds) / 1_000_000_000_000_000_000
+                    let waiter = ApplicationTerminationWaiter(
+                        application: application,
+                        timeoutInterval: timeoutInterval
+                    )
+                    try await waiter.terminate()
+                    terminatedCount += 1
+                }
             }
         },
         openApplication: { applicationURL in

--- a/Sources/XcodeSimulatorHost/System/WorkspaceClient.swift
+++ b/Sources/XcodeSimulatorHost/System/WorkspaceClient.swift
@@ -1,0 +1,53 @@
+import AppKit
+import Foundation
+
+struct RunningApplication: Equatable {
+    let processIdentifier: pid_t
+    let bundleURL: URL?
+}
+
+@MainActor
+struct WorkspaceClient {
+    var runningXcodes: () -> [RunningApplication]
+    var openApplication: (URL) async throws -> URL
+
+    static let live = WorkspaceClient(
+        runningXcodes: {
+            NSRunningApplication.runningApplications(
+                withBundleIdentifier: ToolConstants.xcodeBundleIdentifier
+            ).map {
+                RunningApplication(
+                    processIdentifier: $0.processIdentifier,
+                    bundleURL: $0.bundleURL
+                )
+            }
+        },
+        openApplication: { applicationURL in
+            let configuration = NSWorkspace.OpenConfiguration()
+            configuration.activates = true
+            configuration.createsNewApplicationInstance = false
+            configuration.allowsRunningApplicationSubstitution = false
+
+            let application = try await NSWorkspace.shared.openApplication(
+                at: applicationURL,
+                configuration: configuration
+            )
+            guard let openedURL = application.bundleURL else {
+                throw CLIError.io(
+                    "simulator-launch",
+                    "LaunchServices opened Simulator without a bundle URL"
+                )
+            }
+
+            let expected = applicationURL.resolvingSymlinksInPath().standardizedFileURL
+            let observed = openedURL.resolvingSymlinksInPath().standardizedFileURL
+            guard observed == expected else {
+                throw CLIError.io(
+                    "simulator-substitution",
+                    "requested \(expected.path), but LaunchServices opened \(observed.path)"
+                )
+            }
+            return observed
+        }
+    )
+}

--- a/Sources/XcodeSimulatorHost/ToolConstants.swift
+++ b/Sources/XcodeSimulatorHost/ToolConstants.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+enum ToolConstants {
+    static let name = "xcode-simulator-host"
+    static let version = "0.1.0"
+
+    static let supportedXcodeMajorVersion = 27
+    static let legacyXcodeMajorVersion = 26
+
+    static let xcodeBundleIdentifier = "com.apple.dt.Xcode"
+    static let deviceHubBundleIdentifier = "com.apple.dt.Devices"
+    static let simulatorBundleIdentifier = "com.apple.iphonesimulator"
+
+    static let xcodePreference = ManagedPreference(
+        domain: "com.apple.dt.Xcode",
+        key: "DVTiPhoneSimulatorAlwaysLaunchInCoreSimulatorSession"
+    )
+
+    static let deviceHubPreference = ManagedPreference(
+        domain: "com.apple.dt.Devices",
+        key: "disableAutoStartLiveDeviceView"
+    )
+
+    static let ideIOSSupportCorePath =
+        "Contents/PlugIns/IDEiOSSupportCore.framework/Versions/A/IDEiOSSupportCore"
+    static let deviceHubPath = "Contents/Applications/DeviceHub.app"
+    static let deviceHubImplementationPath = "Contents/MacOS/DeviceHub"
+    static let simulatorPath = "Contents/Developer/Applications/Simulator.app"
+}

--- a/Sources/XcodeSimulatorHost/XcodeSimulatorHostMain.swift
+++ b/Sources/XcodeSimulatorHost/XcodeSimulatorHostMain.swift
@@ -1,0 +1,9 @@
+import Darwin
+
+@main
+struct XcodeSimulatorHostMain {
+    @MainActor
+    static func main() async {
+        Darwin.exit(await runXcodeSimulatorHostCommand(CommandLine.arguments))
+    }
+}

--- a/Sources/xcode_simulator_host/xcode_simulator_host.swift
+++ b/Sources/xcode_simulator_host/xcode_simulator_host.swift
@@ -1,5 +1,0 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book
-public func hello() {
-    print("Hello, world!")
-}

--- a/Tests/XcodeSimulatorHostTests/ArgumentTests.swift
+++ b/Tests/XcodeSimulatorHostTests/ArgumentTests.swift
@@ -13,6 +13,8 @@ struct ArgumentTests {
         #expect(help.contains("use"))
         #expect(help.contains("restore"))
         #expect(help.contains("DEVELOPER_DIR"))
+        #expect(help.contains("Xcode can remain open"))
+        #expect(!help.contains("Quit all Xcode"))
     }
 
     @Test func statusParsesWithoutAnOverride() throws {

--- a/Tests/XcodeSimulatorHostTests/ArgumentTests.swift
+++ b/Tests/XcodeSimulatorHostTests/ArgumentTests.swift
@@ -1,0 +1,124 @@
+import ArgumentParser
+import Foundation
+import Testing
+
+@testable import XcodeSimulatorHost
+
+@Suite
+struct ArgumentTests {
+    @Test func publicHelpContainsTheSupportedCommands() {
+        let help = XcodeSimulatorHostArguments.helpMessage(columns: 100)
+
+        #expect(help.contains("status"))
+        #expect(help.contains("use"))
+        #expect(help.contains("restore"))
+        #expect(help.contains("DEVELOPER_DIR"))
+    }
+
+    @Test func statusParsesWithoutAnOverride() throws {
+        #expect(
+            try parseXcodeSimulatorHostCommand([ToolConstants.name, "status"])
+                == .status(legacyXcode: nil)
+        )
+    }
+
+    @Test func legacyParsesAnAbsoluteXcodePath() throws {
+        let command = try parseXcodeSimulatorHostCommand([
+            ToolConstants.name,
+            "use",
+            "legacy",
+            "--legacy-xcode",
+            "/Applications/Xcode 26.app",
+        ])
+
+        #expect(
+            command == .use(
+                mode: .legacy,
+                legacyXcode: URL(
+                    fileURLWithPath: "/Applications/Xcode 26.app",
+                    isDirectory: true
+                ).standardizedFileURL
+            )
+        )
+    }
+
+    @Test func deviceHubAndRestoreParse() throws {
+        #expect(
+            try parseXcodeSimulatorHostCommand([
+                ToolConstants.name, "use", "device-hub",
+            ]) == .use(mode: .deviceHub, legacyXcode: nil)
+        )
+        #expect(
+            try parseXcodeSimulatorHostCommand([
+                ToolConstants.name, "restore",
+            ]) == .restore(force: false)
+        )
+        #expect(
+            try parseXcodeSimulatorHostCommand([
+                ToolConstants.name, "restore", "--force",
+            ]) == .restore(force: true)
+        )
+    }
+
+    @Test func relativeLegacyXcodePathFailsValidation() {
+        do {
+            _ = try parseXcodeSimulatorHostCommand([
+                ToolConstants.name,
+                "use",
+                "legacy",
+                "--legacy-xcode",
+                "Xcode.app",
+            ])
+            Issue.record("expected relative path to fail")
+        } catch {
+            let message = XcodeSimulatorHostArguments.fullMessage(for: error)
+            #expect(message.contains("Usage: xcode-simulator-host use legacy"))
+        }
+    }
+
+    @Test func unknownModeUsesArgumentParserDiagnostics() {
+        #expect(throws: (any Error).self) {
+            try parseXcodeSimulatorHostCommand([
+                ToolConstants.name, "use", "unknown",
+            ])
+        }
+    }
+
+    @MainActor
+    @Test func helpDoesNotConstructTheLiveApplication() async {
+        var didConstructApplication = false
+        var output: [String] = []
+        let status = await runXcodeSimulatorHostCommand(
+            [ToolConstants.name, "--help"],
+            applicationProvider: {
+                didConstructApplication = true
+                throw CLIError.software("unexpected", "unexpected")
+            },
+            outputLogger: { output.append($0) },
+            errorLogger: { _ in }
+        )
+
+        #expect(status == 0)
+        #expect(!didConstructApplication)
+        #expect(output.joined(separator: "\n").contains("USAGE"))
+    }
+
+    @MainActor
+    @Test func versionDoesNotConstructTheLiveApplication() async {
+        var didConstructApplication = false
+        var output: [String] = []
+        let status = await runXcodeSimulatorHostCommand(
+            [ToolConstants.name, "--version"],
+            applicationProvider: {
+                didConstructApplication = true
+                throw CLIError.software("unexpected", "unexpected")
+            },
+            outputLogger: { output.append($0) },
+            errorLogger: { _ in }
+        )
+
+        #expect(status == 0)
+        #expect(!didConstructApplication)
+        #expect(output == [ToolConstants.version])
+    }
+}

--- a/Tests/XcodeSimulatorHostTests/DefaultsStoreTests.swift
+++ b/Tests/XcodeSimulatorHostTests/DefaultsStoreTests.swift
@@ -22,7 +22,7 @@ struct DefaultsStoreTests {
         )
     }
 
-    @Test func missingDomainsAreReadAsAbsentWhenExportFails() throws {
+    @Test func missingDomainsAreReadAsAbsentWithoutExporting() throws {
         let runner = FakeSystemCommandRunner()
         runner.failMissingDomainExports = true
         let store = DefaultsStore(runner: runner)
@@ -31,8 +31,8 @@ struct DefaultsStoreTests {
         #expect(
             runner.calls.filter {
                 $0.executable.path == "/usr/bin/defaults"
-                    && $0.arguments == ["domains"]
-            }.count == 2
+                    && $0.arguments.first == "export"
+            }.isEmpty
         )
     }
 
@@ -55,7 +55,6 @@ struct DefaultsStoreTests {
 
     @Test func domainListingFailureIsNotTreatedAsAbsent() {
         let runner = FakeSystemCommandRunner()
-        runner.failMissingDomainExports = true
         runner.failDomainListing = true
         let store = DefaultsStore(runner: runner)
 
@@ -135,5 +134,86 @@ struct DefaultsStoreTests {
             )
         }
         #expect(runner.mutationCount == 0)
+    }
+
+    @Test func externalChangeBeforeTheSecondWriteIsNotOverwritten() {
+        let runner = FakeSystemCommandRunner()
+        runner.setStoredValue(true, for: ToolConstants.xcodePreference)
+        runner.setStoredValue(true, for: ToolConstants.deviceHubPreference)
+        var injectedChange = false
+        runner.beforeRun = { call in
+            guard !injectedChange,
+                  runner.mutationCount == 1,
+                  call.executable.path == "/usr/bin/defaults",
+                  call.arguments == ["domains"]
+            else {
+                return
+            }
+            injectedChange = true
+            runner.setStoredValue(false, for: ToolConstants.deviceHubPreference)
+        }
+        let store = DefaultsStore(runner: runner)
+
+        do {
+            _ = try store.apply(.deviceHub, from: .legacy)
+            Issue.record("expected external change to stop the transition")
+        } catch let mismatch as DefaultsStore.StateMismatch {
+            #expect(
+                mismatch.observed
+                    == ManagedPreferenceState(
+                        xcodeSession: .absent,
+                        deviceHubAutoStartSuppression: .falseValue
+                    )
+            )
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+
+        #expect(injectedChange)
+        #expect(runner.mutationCount == 1)
+        #expect(runner.storedBoolean(ToolConstants.xcodePreference) == .absent)
+        #expect(runner.storedBoolean(ToolConstants.deviceHubPreference) == .falseValue)
+    }
+
+    @Test func externalChangeDuringRollbackIsNotOverwritten() {
+        let runner = FakeSystemCommandRunner()
+        runner.setStoredValue(true, for: ToolConstants.xcodePreference)
+        runner.setStoredValue(true, for: ToolConstants.deviceHubPreference)
+        var injectedChange = false
+        runner.beforeRun = { call in
+            guard !injectedChange,
+                  runner.mutationCount == 1,
+                  call.executable.path == "/usr/bin/defaults",
+                  call.arguments == ["domains"]
+            else {
+                return
+            }
+            injectedChange = true
+            runner.setStoredValue(false, for: ToolConstants.deviceHubPreference)
+        }
+        let store = DefaultsStore(runner: runner)
+
+        do {
+            _ = try store.rollback(
+                to: .deviceHub,
+                fromAttemptedTarget: .legacy
+            )
+            Issue.record("expected external change to stop rollback")
+        } catch let mismatch as DefaultsStore.StateMismatch {
+            #expect(
+                mismatch.observed
+                    == ManagedPreferenceState(
+                        xcodeSession: .absent,
+                        deviceHubAutoStartSuppression: .falseValue
+                    )
+            )
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+
+        #expect(injectedChange)
+        #expect(runner.mutationCount == 1)
+        #expect(runner.storedBoolean(ToolConstants.xcodePreference) == .absent)
+        #expect(runner.storedBoolean(ToolConstants.deviceHubPreference) == .falseValue)
     }
 }

--- a/Tests/XcodeSimulatorHostTests/DefaultsStoreTests.swift
+++ b/Tests/XcodeSimulatorHostTests/DefaultsStoreTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Testing
+
+@testable import XcodeSimulatorHost
+
+@Suite
+struct DefaultsStoreTests {
+    @Test func absentFalseAndTrueRemainDistinct() throws {
+        let runner = FakeSystemCommandRunner()
+        let store = DefaultsStore(runner: runner)
+
+        #expect(try store.readState() == .deviceHub)
+
+        runner.setStoredValue(false, for: ToolConstants.xcodePreference)
+        runner.setStoredValue(true, for: ToolConstants.deviceHubPreference)
+        #expect(
+            try store.readState()
+                == ManagedPreferenceState(
+                    xcodeSession: .falseValue,
+                    deviceHubAutoStartSuppression: .trueValue
+                )
+        )
+    }
+
+    @Test func applyWritesAndVerifiesBothPreferences() throws {
+        let runner = FakeSystemCommandRunner()
+        let store = DefaultsStore(runner: runner)
+
+        #expect(try store.apply(.legacy, from: .deviceHub))
+        #expect(runner.storedBoolean(ToolConstants.xcodePreference) == .trueValue)
+        #expect(runner.storedBoolean(ToolConstants.deviceHubPreference) == .trueValue)
+        #expect(runner.mutationCount == 2)
+
+        #expect(!(try store.apply(.legacy, from: .legacy)))
+        #expect(runner.mutationCount == 2)
+
+        #expect(try store.apply(.deviceHub, from: .legacy))
+        #expect(runner.storedBoolean(ToolConstants.xcodePreference) == .absent)
+        #expect(runner.storedBoolean(ToolConstants.deviceHubPreference) == .absent)
+    }
+
+    @Test func nonBooleanValueIsRejectedBeforeMutation() {
+        let runner = FakeSystemCommandRunner()
+        runner.setStoredValue("true", for: ToolConstants.xcodePreference)
+        let store = DefaultsStore(runner: runner)
+
+        do {
+            _ = try store.apply(.legacy, from: .deviceHub)
+            Issue.record("expected invalid preference type")
+        } catch let error as CLIError {
+            #expect(error.identifier == "preference-value-type")
+            #expect(error.category == .configuration)
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+        #expect(runner.mutationCount == 0)
+    }
+
+    @Test func failedMutationLeavesVerificationToTheTransactionOwner() {
+        let runner = FakeSystemCommandRunner()
+        runner.failMutationNumbers = [2]
+        let store = DefaultsStore(runner: runner)
+
+        #expect(throws: CLIError.self) {
+            try store.apply(.legacy, from: .deviceHub)
+        }
+        #expect(runner.storedBoolean(ToolConstants.xcodePreference) == .trueValue)
+        #expect(runner.storedBoolean(ToolConstants.deviceHubPreference) == .absent)
+    }
+
+    @Test func unexpectedCurrentStateIsNeverOverwritten() throws {
+        let runner = FakeSystemCommandRunner()
+        runner.setStoredValue(false, for: ToolConstants.xcodePreference)
+        let store = DefaultsStore(runner: runner)
+
+        do {
+            _ = try store.apply(.legacy, from: .deviceHub)
+            Issue.record("expected stale state to fail")
+        } catch let mismatch as DefaultsStore.StateMismatch {
+            #expect(mismatch.expected == [.deviceHub])
+            #expect(
+                mismatch.observed
+                    == ManagedPreferenceState(
+                        xcodeSession: .falseValue,
+                        deviceHubAutoStartSuppression: .absent
+                    )
+            )
+        }
+        #expect(runner.mutationCount == 0)
+    }
+}

--- a/Tests/XcodeSimulatorHostTests/DefaultsStoreTests.swift
+++ b/Tests/XcodeSimulatorHostTests/DefaultsStoreTests.swift
@@ -22,6 +22,54 @@ struct DefaultsStoreTests {
         )
     }
 
+    @Test func missingDomainsAreReadAsAbsentWhenExportFails() throws {
+        let runner = FakeSystemCommandRunner()
+        runner.failMissingDomainExports = true
+        let store = DefaultsStore(runner: runner)
+
+        #expect(try store.readState() == .deviceHub)
+        #expect(
+            runner.calls.filter {
+                $0.executable.path == "/usr/bin/defaults"
+                    && $0.arguments == ["domains"]
+            }.count == 2
+        )
+    }
+
+    @Test func exportFailureForAnExistingDomainIsNotTreatedAsAbsent() {
+        let runner = FakeSystemCommandRunner()
+        runner.setStoredValue(false, for: ToolConstants.xcodePreference)
+        runner.failExportNumber = 1
+        let store = DefaultsStore(runner: runner)
+
+        do {
+            _ = try store.readState()
+            Issue.record("expected export failure")
+        } catch let error as CLIError {
+            #expect(error.identifier == "preference-read")
+            #expect(error.category == .io)
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    @Test func domainListingFailureIsNotTreatedAsAbsent() {
+        let runner = FakeSystemCommandRunner()
+        runner.failMissingDomainExports = true
+        runner.failDomainListing = true
+        let store = DefaultsStore(runner: runner)
+
+        do {
+            _ = try store.readState()
+            Issue.record("expected domain listing failure")
+        } catch let error as CLIError {
+            #expect(error.identifier == "preference-read")
+            #expect(error.category == .io)
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
     @Test func applyWritesAndVerifiesBothPreferences() throws {
         let runner = FakeSystemCommandRunner()
         let store = DefaultsStore(runner: runner)

--- a/Tests/XcodeSimulatorHostTests/HostModeControllerTests.swift
+++ b/Tests/XcodeSimulatorHostTests/HostModeControllerTests.swift
@@ -8,6 +8,17 @@ import Testing
 struct HostModeControllerTests {
     @Test func legacyAndDeviceHubModesRoundTripTheOriginalAbsentState() async throws {
         let fixture = try ControllerFixture()
+        fixture.workspace.deviceHubCount = 1
+        fixture.workspace.onTerminateDeviceHubs = {
+            #expect(
+                fixture.runner.storedBoolean(ToolConstants.xcodePreference)
+                    == .trueValue
+            )
+            #expect(
+                fixture.runner.storedBoolean(ToolConstants.deviceHubPreference)
+                    == .trueValue
+            )
+        }
 
         let legacy = try await fixture.controller.use(
             mode: .legacy,
@@ -17,8 +28,23 @@ struct HostModeControllerTests {
         #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .trueValue)
         #expect(fixture.runner.storedBoolean(ToolConstants.deviceHubPreference) == .trueValue)
         #expect(legacy.receiptURL != nil)
+        #expect(legacy.terminatedDeviceHubCount == 1)
+        #expect(legacy.rendered.contains("Xcode 27 can remain open"))
         let simulator = try #require(legacy.simulator)
         #expect(fixture.workspace.openedApplications == [simulator.applicationURL])
+        #expect(
+            fixture.workspace.events
+                == ["terminate-device-hubs", "open-simulator"]
+        )
+        #expect(
+            fixture.workspace.requestedDeviceHubURLs
+                == [
+                    fixture.installations.targetXcodeURL.appendingPathComponent(
+                        ToolConstants.deviceHubPath,
+                        isDirectory: true
+                    ),
+                ]
+        )
         #expect(try fixture.receiptStore.load()?.original == .deviceHub)
 
         let deviceHub = try await fixture.controller.use(
@@ -29,6 +55,11 @@ struct HostModeControllerTests {
         #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .absent)
         #expect(fixture.runner.storedBoolean(ToolConstants.deviceHubPreference) == .absent)
         #expect(deviceHub.receiptURL == nil)
+        #expect(deviceHub.terminatedDeviceHubCount == 0)
+        #expect(
+            fixture.workspace.events
+                == ["terminate-device-hubs", "open-simulator"]
+        )
         #expect(try fixture.receiptStore.load() == nil)
     }
 
@@ -46,12 +77,13 @@ struct HostModeControllerTests {
 
         let restored = try fixture.controller.restore()
         #expect(restored.didRestore)
+        #expect(restored.rendered.contains("Xcode can remain open"))
         #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .falseValue)
         #expect(fixture.runner.storedBoolean(ToolConstants.deviceHubPreference) == .trueValue)
         #expect(try fixture.receiptStore.load() == nil)
     }
 
-    @Test func runningXcodeBlocksEveryPreferenceMutation() async throws {
+    @Test func runningXcodeDoesNotBlockLegacyMode() async throws {
         let fixture = try ControllerFixture()
         fixture.workspace.runningXcodes = [
             RunningApplication(
@@ -60,15 +92,18 @@ struct HostModeControllerTests {
             ),
         ]
 
-        do {
-            _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
-            Issue.record("expected running Xcode to block mutation")
-        } catch let error as CLIError {
-            #expect(error.identifier == "xcode-running")
-            #expect(error.category == .temporary)
-        }
-        #expect(fixture.runner.mutationCount == 0)
-        #expect(try fixture.receiptStore.load() == nil)
+        let report = try await fixture.controller.use(
+            mode: .legacy,
+            explicitLegacyXcodeURL: nil
+        )
+
+        #expect(report.didChange)
+        #expect(fixture.runner.mutationCount == 2)
+        #expect(try fixture.receiptStore.load() != nil)
+        #expect(
+            fixture.workspace.events
+                == ["terminate-device-hubs", "open-simulator"]
+        )
     }
 
     @Test func secondPreferenceFailureRollsBackTheFirstPreference() async throws {
@@ -333,6 +368,118 @@ struct HostModeControllerTests {
         #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .absent)
     }
 
+    @Test func deviceHubTerminationFailureStillOpensSimulator() async throws {
+        let fixture = try ControllerFixture()
+        fixture.workspace.terminateDeviceHubsError = CLIError.temporary(
+            "injected-termination",
+            "injected Device Hub termination failure"
+        )
+
+        do {
+            _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
+            Issue.record("expected Device Hub termination failure")
+        } catch let error as CLIError {
+            #expect(error.identifier == "device-hub-termination-partial-success")
+            #expect(error.category == .temporary)
+        }
+
+        #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .trueValue)
+        #expect(fixture.workspace.openedApplications.count == 1)
+        #expect(
+            fixture.workspace.events
+                == ["terminate-device-hubs", "open-simulator"]
+        )
+        #expect(try fixture.receiptStore.load() != nil)
+    }
+
+    @Test func deviceHubIdentityFailurePreservesConfigurationExitCategory() async throws {
+        let fixture = try ControllerFixture()
+        fixture.workspace.terminateDeviceHubsError = CLIError.configuration(
+            "device-hub-substitution",
+            "injected mismatched Device Hub"
+        )
+
+        do {
+            _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
+            Issue.record("expected Device Hub identity failure")
+        } catch let error as CLIError {
+            #expect(error.identifier == "device-hub-termination-partial-success")
+            #expect(error.category == .configuration)
+        }
+        #expect(fixture.workspace.openedApplications.count == 1)
+    }
+
+    @Test func deviceHubAndSimulatorFailuresAreReportedTogether() async throws {
+        let fixture = try ControllerFixture()
+        fixture.workspace.terminateDeviceHubsError = CLIError.temporary(
+            "injected-termination",
+            "injected Device Hub termination failure"
+        )
+        fixture.workspace.openError = CLIError.io(
+            "injected-open",
+            "injected Simulator open failure"
+        )
+
+        do {
+            _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
+            Issue.record("expected combined legacy host failure")
+        } catch let error as CLIError {
+            #expect(error.identifier == "legacy-host-partial-success")
+            #expect(error.message.contains("Device Hub"))
+            #expect(error.message.contains("Simulator"))
+        }
+    }
+
+    @Test func modeIsRevalidatedAfterClosingDeviceHub() async throws {
+        let fixture = try ControllerFixture()
+        fixture.workspace.onTerminateDeviceHubs = {
+            fixture.runner.setStoredValue(
+                nil,
+                for: ToolConstants.xcodePreference
+            )
+            fixture.runner.setStoredValue(
+                nil,
+                for: ToolConstants.deviceHubPreference
+            )
+        }
+
+        do {
+            _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
+            Issue.record("expected post-await preference conflict")
+        } catch let error as CLIError {
+            #expect(error.identifier == "legacy-host-invalidated")
+            #expect(error.category == .configuration)
+        }
+
+        #expect(fixture.workspace.openedApplications.isEmpty)
+        #expect(fixture.workspace.events == ["terminate-device-hubs"])
+    }
+
+    @Test func simulatorOpenHoldsTheOperationLockAgainstAnotherSwitch() async throws {
+        let fixture = try ControllerFixture()
+        fixture.workspace.onOpenApplication = { _ in
+            do {
+                _ = try await fixture.controller.use(
+                    mode: .deviceHub,
+                    explicitLegacyXcodeURL: nil
+                )
+                Issue.record("expected concurrent switch to be serialized")
+            } catch let error as CLIError {
+                #expect(error.identifier == "operation-lock")
+                #expect(error.category == .temporary)
+            }
+        }
+
+        let report = try await fixture.controller.use(
+            mode: .legacy,
+            explicitLegacyXcodeURL: nil
+        )
+
+        #expect(report.didChange)
+        #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .trueValue)
+        #expect(fixture.runner.storedBoolean(ToolConstants.deviceHubPreference) == .trueValue)
+    }
+
     @Test func simulatorLaunchFailureWithoutAReceiptDoesNotSuggestRestore() async throws {
         let fixture = try ControllerFixture(initialState: .legacy)
         fixture.workspace.openError = CLIError.io("open", "injected open failure")
@@ -366,10 +513,9 @@ struct HostModeControllerTests {
         #expect(fixture.runner.calls.isEmpty)
     }
 
-    @Test func runningXcodeBlocksRestoreWhenAReceiptExists() async throws {
+    @Test func runningXcodeDoesNotBlockRestore() async throws {
         let fixture = try ControllerFixture()
         _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
-        let mutationsBeforeRestore = fixture.runner.mutationCount
         fixture.workspace.runningXcodes = [
             RunningApplication(
                 processIdentifier: 42,
@@ -377,14 +523,30 @@ struct HostModeControllerTests {
             ),
         ]
 
-        do {
-            _ = try fixture.controller.restore()
-            Issue.record("expected running Xcode to block restore")
-        } catch let error as CLIError {
-            #expect(error.identifier == "xcode-running")
-        }
-        #expect(fixture.runner.mutationCount == mutationsBeforeRestore)
-        #expect(try fixture.receiptStore.load() != nil)
+        let report = try fixture.controller.restore()
+
+        #expect(report.didRestore)
+        #expect(fixture.runner.mutationCount == 4)
+        #expect(try fixture.receiptStore.load() == nil)
+    }
+
+    @Test func runningXcodeDoesNotBlockDeviceHubMode() async throws {
+        let fixture = try ControllerFixture(initialState: .legacy)
+        fixture.workspace.runningXcodes = [
+            RunningApplication(
+                processIdentifier: 42,
+                bundleURL: URL(fileURLWithPath: "/Applications/Xcode_27.app")
+            ),
+        ]
+
+        let report = try await fixture.controller.use(
+            mode: .deviceHub,
+            explicitLegacyXcodeURL: nil
+        )
+
+        #expect(report.didChange)
+        #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .absent)
+        #expect(fixture.workspace.events.isEmpty)
     }
 
     @Test func sudoIsRejectedBeforeMutation() async throws {
@@ -401,11 +563,19 @@ struct HostModeControllerTests {
 
     @Test func statusIsReadOnly() throws {
         let fixture = try ControllerFixture()
+        fixture.workspace.runningXcodes = [
+            RunningApplication(
+                processIdentifier: 42,
+                bundleURL: URL(fileURLWithPath: "/Applications/Xcode_27.app")
+            ),
+        ]
         let status = try fixture.controller.status(explicitLegacyXcodeURL: nil)
 
         #expect(status.preferences == .deviceHub)
         #expect(status.legacySimulator != nil)
         #expect(fixture.runner.mutationCount == 0)
         #expect(try fixture.receiptStore.load() == nil)
+        #expect(status.rendered.contains("hot switching is supported"))
+        #expect(!status.rendered.contains("mode changes are blocked"))
     }
 }

--- a/Tests/XcodeSimulatorHostTests/HostModeControllerTests.swift
+++ b/Tests/XcodeSimulatorHostTests/HostModeControllerTests.swift
@@ -1,0 +1,411 @@
+import Foundation
+import Testing
+
+@testable import XcodeSimulatorHost
+
+@MainActor
+@Suite
+struct HostModeControllerTests {
+    @Test func legacyAndDeviceHubModesRoundTripTheOriginalAbsentState() async throws {
+        let fixture = try ControllerFixture()
+
+        let legacy = try await fixture.controller.use(
+            mode: .legacy,
+            explicitLegacyXcodeURL: nil
+        )
+        #expect(legacy.didChange)
+        #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .trueValue)
+        #expect(fixture.runner.storedBoolean(ToolConstants.deviceHubPreference) == .trueValue)
+        #expect(legacy.receiptURL != nil)
+        let simulator = try #require(legacy.simulator)
+        #expect(fixture.workspace.openedApplications == [simulator.applicationURL])
+        #expect(try fixture.receiptStore.load()?.original == .deviceHub)
+
+        let deviceHub = try await fixture.controller.use(
+            mode: .deviceHub,
+            explicitLegacyXcodeURL: nil
+        )
+        #expect(deviceHub.didChange)
+        #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .absent)
+        #expect(fixture.runner.storedBoolean(ToolConstants.deviceHubPreference) == .absent)
+        #expect(deviceHub.receiptURL == nil)
+        #expect(try fixture.receiptStore.load() == nil)
+    }
+
+    @Test func restorePreservesExplicitFalseAndTrueValues() async throws {
+        let original = ManagedPreferenceState(
+            xcodeSession: .falseValue,
+            deviceHubAutoStartSuppression: .trueValue
+        )
+        let fixture = try ControllerFixture(initialState: original)
+
+        _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
+        let loadedReceipt = try fixture.receiptStore.load()
+        let receipt = try #require(loadedReceipt)
+        #expect(receipt.original == original)
+
+        let restored = try fixture.controller.restore()
+        #expect(restored.didRestore)
+        #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .falseValue)
+        #expect(fixture.runner.storedBoolean(ToolConstants.deviceHubPreference) == .trueValue)
+        #expect(try fixture.receiptStore.load() == nil)
+    }
+
+    @Test func runningXcodeBlocksEveryPreferenceMutation() async throws {
+        let fixture = try ControllerFixture()
+        fixture.workspace.runningXcodes = [
+            RunningApplication(
+                processIdentifier: 42,
+                bundleURL: URL(fileURLWithPath: "/Applications/Xcode_27.app")
+            ),
+        ]
+
+        do {
+            _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
+            Issue.record("expected running Xcode to block mutation")
+        } catch let error as CLIError {
+            #expect(error.identifier == "xcode-running")
+            #expect(error.category == .temporary)
+        }
+        #expect(fixture.runner.mutationCount == 0)
+        #expect(try fixture.receiptStore.load() == nil)
+    }
+
+    @Test func secondPreferenceFailureRollsBackTheFirstPreference() async throws {
+        let fixture = try ControllerFixture()
+        fixture.runner.failMutationNumbers = [2]
+
+        do {
+            _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
+            Issue.record("expected injected transition failure")
+        } catch let error as CLIError {
+            #expect(error.identifier == "transition-rolled-back")
+        }
+
+        #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .absent)
+        #expect(fixture.runner.storedBoolean(ToolConstants.deviceHubPreference) == .absent)
+        #expect(try fixture.receiptStore.load() == nil)
+    }
+
+    @Test func failureReportedAfterAWriteIsStillRolledBack() async throws {
+        let fixture = try ControllerFixture()
+        fixture.runner.failMutationNumbers = [1]
+        fixture.runner.failureTiming = .afterMutation
+
+        do {
+            _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
+            Issue.record("expected injected transition failure")
+        } catch let error as CLIError {
+            #expect(error.identifier == "transition-rolled-back")
+        }
+
+        #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .absent)
+        #expect(fixture.runner.storedBoolean(ToolConstants.deviceHubPreference) == .absent)
+        #expect(try fixture.receiptStore.load() == nil)
+    }
+
+    @Test func verificationReadFailureIsRolledBack() async throws {
+        let fixture = try ControllerFixture()
+        fixture.runner.failExportNumber = 5
+
+        do {
+            _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
+            Issue.record("expected injected verification failure")
+        } catch let error as CLIError {
+            #expect(error.identifier == "transition-rolled-back")
+        }
+
+        #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .absent)
+        #expect(fixture.runner.storedBoolean(ToolConstants.deviceHubPreference) == .absent)
+        #expect(try fixture.receiptStore.load() == nil)
+    }
+
+    @Test func rollbackFailureRetainsAnInterruptedJournal() async throws {
+        let fixture = try ControllerFixture()
+        fixture.runner.failMutationNumbers = [2, 3]
+
+        do {
+            _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
+            Issue.record("expected rollback failure")
+        } catch let error as CLIError {
+            #expect(error.identifier == "inconsistent-preferences")
+        }
+
+        #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .trueValue)
+        #expect(fixture.runner.storedBoolean(ToolConstants.deviceHubPreference) == .absent)
+        let status = try fixture.controller.status(explicitLegacyXcodeURL: nil)
+        #expect(status.receiptStatus == .ambiguousIntermediate)
+    }
+
+    @Test func externalPreferenceChangeIsReportedAsAConflict() async throws {
+        let fixture = try ControllerFixture()
+        _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
+        fixture.runner.setStoredValue(false, for: ToolConstants.xcodePreference)
+
+        let status = try fixture.controller.status(explicitLegacyXcodeURL: nil)
+        #expect(status.receiptStatus.hasConflict)
+
+        do {
+            _ = try fixture.controller.restore()
+            Issue.record("expected external conflict")
+        } catch let error as CLIError {
+            #expect(error.identifier == "preference-conflict")
+            #expect(error.category == .configuration)
+        }
+    }
+
+    @Test func changeBetweenReceiptCaptureAndApplyIsNotOverwritten() async throws {
+        let fixture = try ControllerFixture()
+        var exportCount = 0
+        fixture.runner.beforeRun = { call in
+            guard call.executable.path == "/usr/bin/defaults",
+                  call.arguments.first == "export"
+            else {
+                return
+            }
+            exportCount += 1
+            if exportCount == 3 {
+                fixture.runner.setStoredValue(
+                    false,
+                    for: ToolConstants.xcodePreference
+                )
+            }
+        }
+
+        do {
+            _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
+            Issue.record("expected external change to be reported")
+        } catch let error as CLIError {
+            #expect(error.identifier == "preference-conflict")
+        }
+
+        #expect(fixture.runner.mutationCount == 0)
+        #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .falseValue)
+        let loadedReceipt = try fixture.receiptStore.load()
+        let receipt = try #require(loadedReceipt)
+        #expect(receipt.pending == PendingMutation(before: .deviceHub, target: .legacy))
+    }
+
+    @Test func externalChangeMatchingAnIntermediateIsNeverAssumedToBeOurs() async throws {
+        let fixture = try ControllerFixture()
+        var exportCount = 0
+        fixture.runner.beforeRun = { call in
+            guard call.executable.path == "/usr/bin/defaults",
+                  call.arguments.first == "export"
+            else {
+                return
+            }
+            exportCount += 1
+            if exportCount == 3 {
+                fixture.runner.setStoredValue(
+                    true,
+                    for: ToolConstants.xcodePreference
+                )
+            }
+        }
+
+        do {
+            _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
+            Issue.record("expected external change to be reported")
+        } catch let error as CLIError {
+            #expect(error.identifier == "preference-conflict")
+        }
+        fixture.runner.beforeRun = nil
+
+        do {
+            _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
+            Issue.record("expected ambiguous state to remain protected")
+        } catch let error as CLIError {
+            #expect(error.identifier == "ambiguous-intermediate")
+        }
+
+        #expect(fixture.runner.mutationCount == 0)
+        #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .trueValue)
+        #expect(fixture.runner.storedBoolean(ToolConstants.deviceHubPreference) == .absent)
+    }
+
+    @Test func pendingAppliedMutationIsFinalizedBeforeTheNextUse() async throws {
+        let fixture = try ControllerFixture()
+        let xcode = try InstallationInspector(
+            runner: fixture.runner,
+            environment: ["DEVELOPER_DIR": fixture.installations.developerDirectoryURL.path],
+            legacySearchRoots: [fixture.installations.applicationsURL],
+            signatureValidator: .acceptingTestFixtures
+        ).validatedTargetXcode()
+        var receipt = RestorationReceipt(
+            capturedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            xcode: xcode,
+            original: .deviceHub
+        )
+        receipt.pending = PendingMutation(before: .deviceHub, target: .legacy)
+        try fixture.receiptStore.save(receipt)
+        fixture.runner.setStoredValue(true, for: ToolConstants.xcodePreference)
+        fixture.runner.setStoredValue(true, for: ToolConstants.deviceHubPreference)
+
+        let report = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
+        #expect(!report.didChange)
+        let loadedReceipt = try fixture.receiptStore.load()
+        let recovered = try #require(loadedReceipt)
+        #expect(recovered.expectedCurrent == .legacy)
+        #expect(recovered.pending == nil)
+    }
+
+    @Test func ambiguousIntermediateIsNotOverwrittenByTheNextUse() async throws {
+        let fixture = try ControllerFixture()
+        let xcode = try InstallationInspector(
+            runner: fixture.runner,
+            environment: ["DEVELOPER_DIR": fixture.installations.developerDirectoryURL.path],
+            legacySearchRoots: [fixture.installations.applicationsURL],
+            signatureValidator: .acceptingTestFixtures
+        ).validatedTargetXcode()
+        var receipt = RestorationReceipt(
+            capturedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            xcode: xcode,
+            original: .deviceHub
+        )
+        receipt.pending = PendingMutation(before: .deviceHub, target: .legacy)
+        try fixture.receiptStore.save(receipt)
+        fixture.runner.setStoredValue(true, for: ToolConstants.xcodePreference)
+
+        do {
+            _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
+            Issue.record("expected ambiguous intermediate state")
+        } catch let error as CLIError {
+            #expect(error.identifier == "ambiguous-intermediate")
+        }
+
+        #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .trueValue)
+        #expect(fixture.runner.storedBoolean(ToolConstants.deviceHubPreference) == .absent)
+        let loadedReceipt = try fixture.receiptStore.load()
+        let recovered = try #require(loadedReceipt)
+        #expect(recovered.expectedCurrent == .deviceHub)
+        #expect(recovered.pending == PendingMutation(before: .deviceHub, target: .legacy))
+    }
+
+    @Test func forceRestoreCanResolveAnAmbiguousIntermediateState() throws {
+        let fixture = try ControllerFixture()
+        let xcode = try InstallationInspector(
+            runner: fixture.runner,
+            environment: ["DEVELOPER_DIR": fixture.installations.developerDirectoryURL.path],
+            legacySearchRoots: [fixture.installations.applicationsURL],
+            signatureValidator: .acceptingTestFixtures
+        ).validatedTargetXcode()
+        var receipt = RestorationReceipt(
+            capturedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            xcode: xcode,
+            original: .deviceHub
+        )
+        receipt.pending = PendingMutation(before: .deviceHub, target: .legacy)
+        try fixture.receiptStore.save(receipt)
+        fixture.runner.setStoredValue(true, for: ToolConstants.xcodePreference)
+
+        do {
+            _ = try fixture.controller.restore()
+            Issue.record("expected normal restore to preserve ambiguity")
+        } catch let error as CLIError {
+            #expect(error.identifier == "ambiguous-intermediate")
+        }
+        #expect(fixture.runner.mutationCount == 0)
+
+        let report = try fixture.controller.restore(force: true)
+
+        #expect(report.didRestore)
+        #expect(report.restoredState == .deviceHub)
+        #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .absent)
+        #expect(fixture.runner.storedBoolean(ToolConstants.deviceHubPreference) == .absent)
+        #expect(try fixture.receiptStore.load() == nil)
+    }
+
+    @Test func simulatorLaunchFailureLeavesTheCommittedModeRestorable() async throws {
+        let fixture = try ControllerFixture()
+        fixture.workspace.openError = CLIError.io("open", "injected open failure")
+
+        do {
+            _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
+            Issue.record("expected Simulator launch failure")
+        } catch let error as CLIError {
+            #expect(error.identifier == "simulator-launch-partial-success")
+        }
+        #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .trueValue)
+        #expect(try fixture.receiptStore.load() != nil)
+
+        _ = try fixture.controller.restore()
+        #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .absent)
+    }
+
+    @Test func simulatorLaunchFailureWithoutAReceiptDoesNotSuggestRestore() async throws {
+        let fixture = try ControllerFixture(initialState: .legacy)
+        fixture.workspace.openError = CLIError.io("open", "injected open failure")
+
+        do {
+            _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
+            Issue.record("expected Simulator launch failure")
+        } catch let error as CLIError {
+            #expect(error.identifier == "simulator-launch-partial-success")
+            #expect(error.message.contains("No restoration receipt exists"))
+            #expect(!error.message.contains("run restore"))
+        }
+        #expect(try fixture.receiptStore.load() == nil)
+    }
+
+    @Test func restoreWithoutAReceiptIsADocumentedNoOp() throws {
+        let fixture = try ControllerFixture()
+        let report = try fixture.controller.restore()
+
+        #expect(!report.didRestore)
+        #expect(fixture.runner.mutationCount == 0)
+    }
+
+    @Test func restoreWithoutAReceiptDoesNotReadInvalidPreferences() throws {
+        let fixture = try ControllerFixture()
+        fixture.runner.setStoredValue("not-a-boolean", for: ToolConstants.xcodePreference)
+
+        let report = try fixture.controller.restore()
+
+        #expect(!report.didRestore)
+        #expect(fixture.runner.calls.isEmpty)
+    }
+
+    @Test func runningXcodeBlocksRestoreWhenAReceiptExists() async throws {
+        let fixture = try ControllerFixture()
+        _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
+        let mutationsBeforeRestore = fixture.runner.mutationCount
+        fixture.workspace.runningXcodes = [
+            RunningApplication(
+                processIdentifier: 42,
+                bundleURL: URL(fileURLWithPath: "/Applications/Xcode_27.app")
+            ),
+        ]
+
+        do {
+            _ = try fixture.controller.restore()
+            Issue.record("expected running Xcode to block restore")
+        } catch let error as CLIError {
+            #expect(error.identifier == "xcode-running")
+        }
+        #expect(fixture.runner.mutationCount == mutationsBeforeRestore)
+        #expect(try fixture.receiptStore.load() != nil)
+    }
+
+    @Test func sudoIsRejectedBeforeMutation() async throws {
+        let fixture = try ControllerFixture(effectiveUserID: 0)
+
+        do {
+            _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
+            Issue.record("expected root user to be rejected")
+        } catch let error as CLIError {
+            #expect(error.identifier == "root-user")
+        }
+        #expect(fixture.runner.mutationCount == 0)
+    }
+
+    @Test func statusIsReadOnly() throws {
+        let fixture = try ControllerFixture()
+        let status = try fixture.controller.status(explicitLegacyXcodeURL: nil)
+
+        #expect(status.preferences == .deviceHub)
+        #expect(status.legacySimulator != nil)
+        #expect(fixture.runner.mutationCount == 0)
+        #expect(try fixture.receiptStore.load() == nil)
+    }
+}

--- a/Tests/XcodeSimulatorHostTests/HostModeControllerTests.swift
+++ b/Tests/XcodeSimulatorHostTests/HostModeControllerTests.swift
@@ -141,7 +141,7 @@ struct HostModeControllerTests {
 
     @Test func verificationReadFailureIsRolledBack() async throws {
         let fixture = try ControllerFixture()
-        fixture.runner.failExportNumber = 5
+        fixture.runner.failFirstExportAfterMutationCount = 2
 
         do {
             _ = try await fixture.controller.use(mode: .legacy, explicitLegacyXcodeURL: nil)
@@ -189,17 +189,56 @@ struct HostModeControllerTests {
         }
     }
 
-    @Test func changeBetweenReceiptCaptureAndApplyIsNotOverwritten() async throws {
-        let fixture = try ControllerFixture()
-        var exportCount = 0
+    @Test func detectedChangeBetweenWritesIsNotRolledBack() async throws {
+        let fixture = try ControllerFixture(initialState: .legacy)
+        var injectedChange = false
         fixture.runner.beforeRun = { call in
-            guard call.executable.path == "/usr/bin/defaults",
-                  call.arguments.first == "export"
+            guard !injectedChange,
+                  fixture.runner.mutationCount == 1,
+                  call.executable.path == "/usr/bin/defaults",
+                  call.arguments == ["domains"]
             else {
                 return
             }
-            exportCount += 1
-            if exportCount == 3 {
+            injectedChange = true
+            fixture.runner.setStoredValue(
+                false,
+                for: ToolConstants.deviceHubPreference
+            )
+        }
+
+        do {
+            _ = try await fixture.controller.use(
+                mode: .deviceHub,
+                explicitLegacyXcodeURL: nil
+            )
+            Issue.record("expected external change to be reported")
+        } catch let error as CLIError {
+            #expect(error.identifier == "preference-conflict")
+            #expect(error.category == .configuration)
+        }
+
+        #expect(injectedChange)
+        #expect(fixture.runner.mutationCount == 1)
+        #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .absent)
+        #expect(
+            fixture.runner.storedBoolean(ToolConstants.deviceHubPreference)
+                == .falseValue
+        )
+        #expect(try fixture.receiptStore.load()?.pending != nil)
+    }
+
+    @Test func changeBetweenReceiptCaptureAndApplyIsNotOverwritten() async throws {
+        let fixture = try ControllerFixture()
+        var stateReadCount = 0
+        fixture.runner.beforeRun = { call in
+            guard call.executable.path == "/usr/bin/defaults",
+                  call.arguments == ["domains"]
+            else {
+                return
+            }
+            stateReadCount += 1
+            if stateReadCount == 2 {
                 fixture.runner.setStoredValue(
                     false,
                     for: ToolConstants.xcodePreference
@@ -223,15 +262,15 @@ struct HostModeControllerTests {
 
     @Test func externalChangeMatchingAnIntermediateIsNeverAssumedToBeOurs() async throws {
         let fixture = try ControllerFixture()
-        var exportCount = 0
+        var stateReadCount = 0
         fixture.runner.beforeRun = { call in
             guard call.executable.path == "/usr/bin/defaults",
-                  call.arguments.first == "export"
+                  call.arguments == ["domains"]
             else {
                 return
             }
-            exportCount += 1
-            if exportCount == 3 {
+            stateReadCount += 1
+            if stateReadCount == 2 {
                 fixture.runner.setStoredValue(
                     true,
                     for: ToolConstants.xcodePreference
@@ -642,7 +681,7 @@ struct HostModeControllerTests {
         fixture.runner.beforeRun = { call in
             guard !createdState,
                   call.executable.path == "/usr/bin/defaults",
-                  call.arguments.first == "export"
+                  call.arguments == ["domains"]
             else {
                 return
             }
@@ -662,8 +701,8 @@ struct HostModeControllerTests {
         #expect(
             fixture.runner.calls.filter {
                 $0.executable.path == "/usr/bin/defaults"
-                    && $0.arguments.first == "export"
-            }.count == 4
+                    && $0.arguments == ["domains"]
+            }.count == 2
         )
     }
 }

--- a/Tests/XcodeSimulatorHostTests/HostModeControllerTests.swift
+++ b/Tests/XcodeSimulatorHostTests/HostModeControllerTests.swift
@@ -480,6 +480,43 @@ struct HostModeControllerTests {
         #expect(fixture.runner.storedBoolean(ToolConstants.deviceHubPreference) == .trueValue)
     }
 
+    @Test func deviceHubTerminationHoldsTheOperationLockAgainstNewMutations() async throws {
+        let fixture = try ControllerFixture()
+        fixture.workspace.onTerminateDeviceHubs = {
+            do {
+                _ = try await fixture.controller.use(
+                    mode: .deviceHub,
+                    explicitLegacyXcodeURL: nil
+                )
+                Issue.record("expected concurrent switch to be serialized")
+            } catch let error as CLIError {
+                #expect(error.identifier == "operation-lock")
+                #expect(error.category == .temporary)
+            } catch {
+                Issue.record("unexpected switch error: \(error)")
+            }
+
+            do {
+                _ = try fixture.controller.restore()
+                Issue.record("expected concurrent restore to be serialized")
+            } catch let error as CLIError {
+                #expect(error.identifier == "operation-lock")
+                #expect(error.category == .temporary)
+            } catch {
+                Issue.record("unexpected restore error: \(error)")
+            }
+        }
+
+        let report = try await fixture.controller.use(
+            mode: .legacy,
+            explicitLegacyXcodeURL: nil
+        )
+
+        #expect(report.didChange)
+        #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .trueValue)
+        #expect(fixture.runner.storedBoolean(ToolConstants.deviceHubPreference) == .trueValue)
+    }
+
     @Test func simulatorLaunchFailureWithoutAReceiptDoesNotSuggestRestore() async throws {
         let fixture = try ControllerFixture(initialState: .legacy)
         fixture.workspace.openError = CLIError.io("open", "injected open failure")

--- a/Tests/XcodeSimulatorHostTests/HostModeControllerTests.swift
+++ b/Tests/XcodeSimulatorHostTests/HostModeControllerTests.swift
@@ -534,10 +534,20 @@ struct HostModeControllerTests {
 
     @Test func restoreWithoutAReceiptIsADocumentedNoOp() throws {
         let fixture = try ControllerFixture()
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: fixture.receiptStore.directoryURL.path
+            )
+        )
         let report = try fixture.controller.restore()
 
         #expect(!report.didRestore)
         #expect(fixture.runner.mutationCount == 0)
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: fixture.receiptStore.directoryURL.path
+            )
+        )
     }
 
     @Test func restoreWithoutAReceiptDoesNotReadInvalidPreferences() throws {
@@ -600,6 +610,11 @@ struct HostModeControllerTests {
 
     @Test func statusIsReadOnly() throws {
         let fixture = try ControllerFixture()
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: fixture.receiptStore.directoryURL.path
+            )
+        )
         fixture.workspace.runningXcodes = [
             RunningApplication(
                 processIdentifier: 42,
@@ -612,7 +627,43 @@ struct HostModeControllerTests {
         #expect(status.legacySimulator != nil)
         #expect(fixture.runner.mutationCount == 0)
         #expect(try fixture.receiptStore.load() == nil)
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: fixture.receiptStore.directoryURL.path
+            )
+        )
         #expect(status.rendered.contains("hot switching is supported"))
         #expect(!status.rendered.contains("mode changes are blocked"))
+    }
+
+    @Test func statusRetriesWhenStateAppearsDuringTheOptimisticSnapshot() throws {
+        let fixture = try ControllerFixture()
+        var createdState = false
+        fixture.runner.beforeRun = { call in
+            guard !createdState,
+                  call.executable.path == "/usr/bin/defaults",
+                  call.arguments.first == "export"
+            else {
+                return
+            }
+            createdState = true
+            do {
+                try fixture.receiptStore.withExclusiveLock {}
+            } catch {
+                Issue.record("could not create simulated concurrent state: \(error)")
+            }
+        }
+
+        let status = try fixture.controller.status(explicitLegacyXcodeURL: nil)
+
+        #expect(createdState)
+        #expect(status.preferences == .deviceHub)
+        #expect(status.receiptStatus == .unmanaged)
+        #expect(
+            fixture.runner.calls.filter {
+                $0.executable.path == "/usr/bin/defaults"
+                    && $0.arguments.first == "export"
+            }.count == 4
+        )
     }
 }

--- a/Tests/XcodeSimulatorHostTests/HostModeControllerTests.swift
+++ b/Tests/XcodeSimulatorHostTests/HostModeControllerTests.swift
@@ -312,7 +312,9 @@ struct HostModeControllerTests {
             original: .deviceHub
         )
         receipt.pending = PendingMutation(before: .deviceHub, target: .legacy)
-        try fixture.receiptStore.save(receipt)
+        try fixture.receiptStore.withExclusiveLock {
+            try fixture.receiptStore.save(receipt)
+        }
         fixture.runner.setStoredValue(true, for: ToolConstants.xcodePreference)
         fixture.runner.setStoredValue(true, for: ToolConstants.deviceHubPreference)
 
@@ -338,7 +340,9 @@ struct HostModeControllerTests {
             original: .deviceHub
         )
         receipt.pending = PendingMutation(before: .deviceHub, target: .legacy)
-        try fixture.receiptStore.save(receipt)
+        try fixture.receiptStore.withExclusiveLock {
+            try fixture.receiptStore.save(receipt)
+        }
         fixture.runner.setStoredValue(true, for: ToolConstants.xcodePreference)
 
         do {
@@ -370,7 +374,9 @@ struct HostModeControllerTests {
             original: .deviceHub
         )
         receipt.pending = PendingMutation(before: .deviceHub, target: .legacy)
-        try fixture.receiptStore.save(receipt)
+        try fixture.receiptStore.withExclusiveLock {
+            try fixture.receiptStore.save(receipt)
+        }
         fixture.runner.setStoredValue(true, for: ToolConstants.xcodePreference)
 
         do {
@@ -614,6 +620,39 @@ struct HostModeControllerTests {
         #expect(report.didRestore)
         #expect(fixture.runner.mutationCount == 4)
         #expect(try fixture.receiptStore.load() == nil)
+    }
+
+    @Test func restoreIsSerializedBeforeUseCapturesItsReceipt() async throws {
+        let fixture = try ControllerFixture()
+        var checkedRestore = false
+        fixture.runner.beforeRun = { call in
+            guard !checkedRestore,
+                  call.executable.path == "/usr/bin/defaults",
+                  call.arguments == ["domains"]
+            else {
+                return
+            }
+            checkedRestore = true
+            do {
+                _ = try fixture.controller.restore()
+                Issue.record("expected restore to observe the active operation lock")
+            } catch let error as CLIError {
+                #expect(error.identifier == "operation-lock")
+                #expect(error.category == .temporary)
+            } catch {
+                Issue.record("unexpected restore error: \(error)")
+            }
+        }
+
+        let report = try await fixture.controller.use(
+            mode: .legacy,
+            explicitLegacyXcodeURL: nil
+        )
+
+        #expect(checkedRestore)
+        #expect(report.didChange)
+        #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .trueValue)
+        #expect(fixture.runner.storedBoolean(ToolConstants.deviceHubPreference) == .trueValue)
     }
 
     @Test func runningXcodeDoesNotBlockDeviceHubMode() async throws {

--- a/Tests/XcodeSimulatorHostTests/InstallationInspectorTests.swift
+++ b/Tests/XcodeSimulatorHostTests/InstallationInspectorTests.swift
@@ -132,7 +132,7 @@ struct InstallationInspectorTests {
         }
     }
 
-    @Test func legacySimulatorMustHaveAnAppleCodeSignature() throws {
+    @Test func legacyXcodeMustHaveAnAppleCodeSignature() throws {
         let fixture = try InstallationFixture()
         let inspector = InstallationInspector(
             runner: FakeSystemCommandRunner(),
@@ -153,6 +153,70 @@ struct InstallationInspectorTests {
             Issue.record("expected invalid code signature to fail")
         } catch let error as CLIError {
             #expect(error.identifier == "code-signature")
+        }
+    }
+
+    @Test func legacySimulatorMustHaveAnAppleCodeSignature() throws {
+        let fixture = try InstallationFixture()
+        let inspector = InstallationInspector(
+            runner: FakeSystemCommandRunner(),
+            environment: ["DEVELOPER_DIR": fixture.developerDirectoryURL.path],
+            legacySearchRoots: [fixture.applicationsURL],
+            signatureValidator: CodeSignatureValidator { _, bundleIdentifier in
+                if bundleIdentifier == ToolConstants.simulatorBundleIdentifier {
+                    throw CLIError.unavailable(
+                        "code-signature",
+                        "injected invalid Simulator signature"
+                    )
+                }
+            }
+        )
+
+        do {
+            _ = try inspector.legacySimulator(
+                explicitXcodeURL: fixture.legacyXcodeURL
+            )
+            Issue.record("expected invalid Simulator code signature to fail")
+        } catch let error as CLIError {
+            #expect(error.identifier == "code-signature")
+        }
+    }
+
+    @Test func signedSimulatorMustIdentifyXcode26() throws {
+        let fixture = try InstallationFixture()
+        let infoURL = fixture.legacyXcodeURL
+            .appendingPathComponent(ToolConstants.simulatorPath, isDirectory: true)
+            .appendingPathComponent("Contents/Info.plist")
+        let data = try Data(contentsOf: infoURL)
+        guard var info = try PropertyListSerialization.propertyList(
+            from: data,
+            options: [],
+            format: nil
+        ) as? [String: Any] else {
+            Issue.record("invalid test fixture Info.plist")
+            return
+        }
+        info["DTXcode"] = "2700"
+        let modifiedData = try PropertyListSerialization.data(
+            fromPropertyList: info,
+            format: .xml,
+            options: 0
+        )
+        try modifiedData.write(to: infoURL)
+        let inspector = InstallationInspector(
+            runner: FakeSystemCommandRunner(),
+            environment: ["DEVELOPER_DIR": fixture.developerDirectoryURL.path],
+            legacySearchRoots: [fixture.applicationsURL],
+            signatureValidator: .acceptingTestFixtures
+        )
+
+        do {
+            _ = try inspector.legacySimulator(
+                explicitXcodeURL: fixture.legacyXcodeURL
+            )
+            Issue.record("expected mismatched DTXcode to fail")
+        } catch let error as CLIError {
+            #expect(error.identifier == "legacy-simulator-bundle")
         }
     }
 

--- a/Tests/XcodeSimulatorHostTests/InstallationInspectorTests.swift
+++ b/Tests/XcodeSimulatorHostTests/InstallationInspectorTests.swift
@@ -1,0 +1,164 @@
+import Foundation
+import Testing
+
+@testable import XcodeSimulatorHost
+
+@Suite
+struct InstallationInspectorTests {
+    @Test func validatesTheSelectedXcodeAndHiddenKey() throws {
+        let fixture = try InstallationFixture()
+        let runner = FakeSystemCommandRunner()
+        let inspector = InstallationInspector(
+            runner: runner,
+            environment: ["DEVELOPER_DIR": fixture.developerDirectoryURL.path],
+            legacySearchRoots: [fixture.applicationsURL],
+            signatureValidator: .acceptingTestFixtures
+        )
+
+        let xcode = try inspector.validatedTargetXcode()
+        #expect(xcode.applicationURL == fixture.targetXcodeURL)
+        #expect(xcode.version == (try ToolVersion("27.0")))
+        #expect(xcode.buildVersion == "27A5252f")
+    }
+
+    @Test func rejectsAnUnverifiedXcodeMajor() throws {
+        let fixture = try InstallationFixture(targetVersion: "28.0")
+        let inspector = InstallationInspector(
+            runner: FakeSystemCommandRunner(),
+            environment: ["DEVELOPER_DIR": fixture.developerDirectoryURL.path],
+            legacySearchRoots: [fixture.applicationsURL],
+            signatureValidator: .acceptingTestFixtures
+        )
+
+        do {
+            _ = try inspector.validatedTargetXcode()
+            Issue.record("expected Xcode 28 to be rejected")
+        } catch let error as CLIError {
+            #expect(error.identifier == "unsupported-xcode")
+            #expect(error.category == .unavailable)
+        }
+    }
+
+    @Test func rejectsXcodeWhenTheHiddenKeyDisappears() throws {
+        let fixture = try InstallationFixture(includeHiddenKey: false)
+        let inspector = InstallationInspector(
+            runner: FakeSystemCommandRunner(),
+            environment: ["DEVELOPER_DIR": fixture.developerDirectoryURL.path],
+            legacySearchRoots: [fixture.applicationsURL],
+            signatureValidator: .acceptingTestFixtures
+        )
+
+        do {
+            _ = try inspector.validatedTargetXcode()
+            Issue.record("expected missing key to fail")
+        } catch let error as CLIError {
+            #expect(error.identifier == "xcode-preference-key")
+        }
+    }
+
+    @Test func rejectsXcodeWhenDeviceHubIsNotLaunchable() throws {
+        let fixture = try InstallationFixture()
+        let executableURL = fixture.targetXcodeURL
+            .appendingPathComponent(ToolConstants.deviceHubPath, isDirectory: true)
+            .appendingPathComponent("Contents/MacOS/DevicesTrampoline")
+        try FileManager.default.removeItem(at: executableURL)
+        let inspector = InstallationInspector(
+            runner: FakeSystemCommandRunner(),
+            environment: ["DEVELOPER_DIR": fixture.developerDirectoryURL.path],
+            legacySearchRoots: [fixture.applicationsURL],
+            signatureValidator: .acceptingTestFixtures
+        )
+
+        do {
+            _ = try inspector.validatedTargetXcode()
+            Issue.record("expected missing Device Hub executable to fail")
+        } catch let error as CLIError {
+            #expect(error.identifier == "device-hub-executable")
+        }
+    }
+
+    @Test func rejectsXcodeWhenTheDeviceHubKeyDisappears() throws {
+        let fixture = try InstallationFixture(includeDeviceHubKey: false)
+        let inspector = InstallationInspector(
+            runner: FakeSystemCommandRunner(),
+            environment: ["DEVELOPER_DIR": fixture.developerDirectoryURL.path],
+            legacySearchRoots: [fixture.applicationsURL],
+            signatureValidator: .acceptingTestFixtures
+        )
+
+        do {
+            _ = try inspector.validatedTargetXcode()
+            Issue.record("expected missing Device Hub key to fail")
+        } catch let error as CLIError {
+            #expect(error.identifier == "device-hub-preference-key")
+        }
+    }
+
+    @Test func choosesTheHighestValidatedXcode26() throws {
+        let fixture = try InstallationFixture(
+            legacyVersions: [
+                ("Xcode_26.3.app", "26.3", "17C529"),
+                ("Xcode_26.5.app", "26.5", "17F42"),
+                ("Xcode.app", "26.6", "17F109"),
+            ]
+        )
+        let inspector = InstallationInspector(
+            runner: FakeSystemCommandRunner(),
+            environment: ["DEVELOPER_DIR": fixture.developerDirectoryURL.path],
+            legacySearchRoots: [fixture.applicationsURL],
+            signatureValidator: .acceptingTestFixtures
+        )
+
+        let simulator = try inspector.legacySimulator(explicitXcodeURL: nil)
+        #expect(simulator.xcode.version == (try ToolVersion("26.6")))
+        #expect(simulator.xcode.buildVersion == "17F109")
+        #expect(simulator.applicationURL.path.hasSuffix(ToolConstants.simulatorPath))
+    }
+
+    @Test func explicitLegacyXcodeMustBeVersion26() throws {
+        let fixture = try InstallationFixture()
+        let inspector = InstallationInspector(
+            runner: FakeSystemCommandRunner(),
+            environment: ["DEVELOPER_DIR": fixture.developerDirectoryURL.path],
+            legacySearchRoots: [fixture.applicationsURL],
+            signatureValidator: .acceptingTestFixtures
+        )
+
+        do {
+            _ = try inspector.legacySimulator(explicitXcodeURL: fixture.targetXcodeURL)
+            Issue.record("expected Xcode 27 legacy host to fail")
+        } catch let error as CLIError {
+            #expect(error.identifier == "legacy-xcode-version")
+        }
+    }
+
+    @Test func legacySimulatorMustHaveAnAppleCodeSignature() throws {
+        let fixture = try InstallationFixture()
+        let inspector = InstallationInspector(
+            runner: FakeSystemCommandRunner(),
+            environment: ["DEVELOPER_DIR": fixture.developerDirectoryURL.path],
+            legacySearchRoots: [fixture.applicationsURL],
+            signatureValidator: CodeSignatureValidator { _, _ in
+                throw CLIError.unavailable(
+                    "code-signature",
+                    "injected invalid signature"
+                )
+            }
+        )
+
+        do {
+            _ = try inspector.legacySimulator(
+                explicitXcodeURL: fixture.legacyXcodeURL
+            )
+            Issue.record("expected invalid code signature to fail")
+        } catch let error as CLIError {
+            #expect(error.identifier == "code-signature")
+        }
+    }
+
+    @Test func versionComparisonPadsMissingComponents() throws {
+        #expect(try ToolVersion("26.6") == ToolVersion("26.6.0"))
+        #expect(try ToolVersion("26.6.1") > ToolVersion("26.6"))
+        #expect(try ToolVersion("27.0") > ToolVersion("26.99"))
+    }
+}

--- a/Tests/XcodeSimulatorHostTests/ReceiptStoreTests.swift
+++ b/Tests/XcodeSimulatorHostTests/ReceiptStoreTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Testing
+
+@testable import XcodeSimulatorHost
+
+@Suite
+struct ReceiptStoreTests {
+    @Test func receiptRoundTripsAndDeletes() throws {
+        let directory = try TemporaryTestDirectory()
+        let store = try ReceiptStore(directoryURL: directory.url)
+        let xcode = XcodeInstallation(
+            applicationURL: URL(fileURLWithPath: "/Applications/Xcode_27.app"),
+            version: try ToolVersion("27.0"),
+            buildVersion: "27A5252f"
+        )
+        var receipt = RestorationReceipt(
+            capturedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            xcode: xcode,
+            original: ManagedPreferenceState(
+                xcodeSession: .falseValue,
+                deviceHubAutoStartSuppression: .absent
+            )
+        )
+        receipt.expectedCurrent = .legacy
+        receipt.pending = PendingMutation(before: .legacy, target: .deviceHub)
+
+        try store.save(receipt)
+        #expect(try store.load() == receipt)
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: store.receiptURL.path)
+        #expect((attributes[.posixPermissions] as? NSNumber)?.intValue == 0o600)
+
+        try store.deleteReceipt()
+        #expect(try store.load() == nil)
+    }
+
+    @Test func corruptReceiptIsNeverTreatedAsAbsent() throws {
+        let directory = try TemporaryTestDirectory()
+        let store = try ReceiptStore(directoryURL: directory.url)
+        try FileManager.default.createDirectory(
+            at: store.directoryURL,
+            withIntermediateDirectories: true
+        )
+        try Data("not a plist".utf8).write(to: store.receiptURL)
+
+        do {
+            _ = try store.load()
+            Issue.record("expected corrupt receipt to fail")
+        } catch let error as CLIError {
+            #expect(error.identifier == "receipt-decode")
+            #expect(error.category == .configuration)
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    @Test func invalidPendingJournalIsRejected() throws {
+        let xcode = XcodeInstallation(
+            applicationURL: URL(fileURLWithPath: "/Applications/Xcode_27.app"),
+            version: try ToolVersion("27.0"),
+            buildVersion: "27A5252f"
+        )
+        var wrongBefore = RestorationReceipt(
+            capturedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            xcode: xcode,
+            original: .deviceHub
+        )
+        wrongBefore.pending = PendingMutation(before: .legacy, target: .deviceHub)
+        #expect(throws: CLIError.self) {
+            try wrongBefore.validate()
+        }
+
+        var noOp = RestorationReceipt(
+            capturedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            xcode: xcode,
+            original: .deviceHub
+        )
+        noOp.pending = PendingMutation(before: .deviceHub, target: .deviceHub)
+        #expect(throws: CLIError.self) {
+            try noOp.validate()
+        }
+    }
+
+    @Test func nestedInvocationCannotAcquireTheSameLock() throws {
+        let directory = try TemporaryTestDirectory()
+        let store = try ReceiptStore(directoryURL: directory.url)
+
+        try store.withExclusiveLock {
+            do {
+                try store.withExclusiveLock {}
+                Issue.record("expected nested lock acquisition to fail")
+            } catch let error as CLIError {
+                #expect(error.identifier == "operation-lock")
+                #expect(error.category == .temporary)
+            }
+        }
+    }
+
+    @Test func symbolicLinkCannotBecomeTheOperationLock() throws {
+        let directory = try TemporaryTestDirectory()
+        let store = try ReceiptStore(directoryURL: directory.url)
+        try FileManager.default.createDirectory(
+            at: store.directoryURL,
+            withIntermediateDirectories: true
+        )
+        let target = directory.url.appendingPathComponent("target")
+        try Data().write(to: target)
+        try FileManager.default.createSymbolicLink(
+            at: store.lockURL,
+            withDestinationURL: target
+        )
+
+        #expect(throws: CLIError.self) {
+            try store.withExclusiveLock {}
+        }
+    }
+
+    @Test func symbolicLinkCannotBecomeTheStateDirectory() throws {
+        let directory = try TemporaryTestDirectory()
+        let target = directory.url.appendingPathComponent("target", isDirectory: true)
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: false)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: target.path
+        )
+        let linkedState = directory.url.appendingPathComponent("linked-state", isDirectory: true)
+        try FileManager.default.createSymbolicLink(
+            at: linkedState,
+            withDestinationURL: target
+        )
+        let store = try ReceiptStore(directoryURL: linkedState)
+
+        #expect(throws: CLIError.self) {
+            try store.withExclusiveLock {}
+        }
+        let attributes = try FileManager.default.attributesOfItem(atPath: target.path)
+        #expect((attributes[.posixPermissions] as? NSNumber)?.intValue == 0o755)
+    }
+}

--- a/Tests/XcodeSimulatorHostTests/TestSupport.swift
+++ b/Tests/XcodeSimulatorHostTests/TestSupport.swift
@@ -402,7 +402,12 @@ struct ControllerFixture {
             for: ToolConstants.deviceHubPreference
         )
         workspace = WorkspaceRecorder()
-        receiptStore = try ReceiptStore(directoryURL: stateDirectory.url)
+        receiptStore = try ReceiptStore(
+            directoryURL: stateDirectory.url.appendingPathComponent(
+                "state",
+                isDirectory: true
+            )
+        )
 
         let inspector = InstallationInspector(
             runner: runner,

--- a/Tests/XcodeSimulatorHostTests/TestSupport.swift
+++ b/Tests/XcodeSimulatorHostTests/TestSupport.swift
@@ -177,7 +177,7 @@ final class WorkspaceRecorder {
     var runningXcodes: [RunningApplication] = []
     var deviceHubCount = 0
     var terminateDeviceHubsError: (any Error)?
-    var onTerminateDeviceHubs: (() -> Void)?
+    var onTerminateDeviceHubs: (() async -> Void)?
     private(set) var requestedDeviceHubURLs: [URL] = []
     var openedApplications: [URL] = []
     var openError: (any Error)?
@@ -190,7 +190,7 @@ final class WorkspaceRecorder {
             terminateDeviceHubs: { url in
                 self.events.append("terminate-device-hubs")
                 self.requestedDeviceHubURLs.append(url)
-                self.onTerminateDeviceHubs?()
+                await self.onTerminateDeviceHubs?()
                 if let terminateDeviceHubsError = self.terminateDeviceHubsError {
                     throw terminateDeviceHubsError
                 }

--- a/Tests/XcodeSimulatorHostTests/TestSupport.swift
+++ b/Tests/XcodeSimulatorHostTests/TestSupport.swift
@@ -38,6 +38,7 @@ final class FakeSystemCommandRunner: CommandRunning {
     var selectedDeveloperDirectory: URL?
     var failMutationNumbers: Set<Int> = []
     var failExportNumber: Int?
+    var failFirstExportAfterMutationCount: Int?
     var failMissingDomainExports = false
     var failDomainListing = false
     var failureTiming: FailureTiming = .beforeMutation
@@ -104,6 +105,10 @@ final class FakeSystemCommandRunner: CommandRunning {
             exportCount += 1
             if failExportNumber == exportCount {
                 return failure("injected export failure")
+            }
+            if failFirstExportAfterMutationCount == mutationCount {
+                failFirstExportAfterMutationCount = nil
+                return failure("injected post-mutation export failure")
             }
             guard let domain = domains[arguments[1]] else {
                 if failMissingDomainExports {

--- a/Tests/XcodeSimulatorHostTests/TestSupport.swift
+++ b/Tests/XcodeSimulatorHostTests/TestSupport.swift
@@ -155,14 +155,33 @@ final class FakeSystemCommandRunner: CommandRunning {
 @MainActor
 final class WorkspaceRecorder {
     var runningXcodes: [RunningApplication] = []
+    var deviceHubCount = 0
+    var terminateDeviceHubsError: (any Error)?
+    var onTerminateDeviceHubs: (() -> Void)?
+    private(set) var requestedDeviceHubURLs: [URL] = []
     var openedApplications: [URL] = []
     var openError: (any Error)?
+    var onOpenApplication: ((URL) async throws -> Void)?
+    private(set) var events: [String] = []
 
     var client: WorkspaceClient {
         WorkspaceClient(
             runningXcodes: { self.runningXcodes },
+            terminateDeviceHubs: { url in
+                self.events.append("terminate-device-hubs")
+                self.requestedDeviceHubURLs.append(url)
+                self.onTerminateDeviceHubs?()
+                if let terminateDeviceHubsError = self.terminateDeviceHubsError {
+                    throw terminateDeviceHubsError
+                }
+                return self.deviceHubCount
+            },
             openApplication: { url in
+                self.events.append("open-simulator")
                 self.openedApplications.append(url)
+                if let onOpenApplication = self.onOpenApplication {
+                    try await onOpenApplication(url)
+                }
                 if let openError = self.openError {
                     throw openError
                 }

--- a/Tests/XcodeSimulatorHostTests/TestSupport.swift
+++ b/Tests/XcodeSimulatorHostTests/TestSupport.swift
@@ -38,6 +38,8 @@ final class FakeSystemCommandRunner: CommandRunning {
     var selectedDeveloperDirectory: URL?
     var failMutationNumbers: Set<Int> = []
     var failExportNumber: Int?
+    var failMissingDomainExports = false
+    var failDomainListing = false
     var failureTiming: FailureTiming = .beforeMutation
     var beforeRun: ((Call) -> Void)?
     private(set) var calls: [Call] = []
@@ -86,6 +88,15 @@ final class FakeSystemCommandRunner: CommandRunning {
         }
 
         switch operation {
+        case "domains":
+            guard arguments.count == 1 else {
+                return failure("invalid domains arguments")
+            }
+            if failDomainListing {
+                return failure("injected domain listing failure")
+            }
+            return success(domains.keys.sorted().joined(separator: ", "))
+
         case "export":
             guard arguments.count == 3, arguments[2] == "-" else {
                 return failure("invalid export arguments")
@@ -94,13 +105,13 @@ final class FakeSystemCommandRunner: CommandRunning {
             if failExportNumber == exportCount {
                 return failure("injected export failure")
             }
-            let domain = domains[arguments[1], default: [:]]
-            let data = try PropertyListSerialization.data(
-                fromPropertyList: domain,
-                format: .xml,
-                options: 0
-            )
-            return CommandOutput(terminationStatus: 0, stdout: data, stderr: Data())
+            guard let domain = domains[arguments[1]] else {
+                if failMissingDomainExports {
+                    return failure("domain does not exist")
+                }
+                return try exportedDomain([:])
+            }
+            return try exportedDomain(domain)
 
         case "write":
             guard arguments.count == 5, arguments[3] == "-bool" else {
@@ -133,6 +144,15 @@ final class FakeSystemCommandRunner: CommandRunning {
         default:
             return failure("unexpected defaults operation")
         }
+    }
+
+    private func exportedDomain(_ domain: [String: Any]) throws -> CommandOutput {
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: domain,
+            format: .xml,
+            options: 0
+        )
+        return CommandOutput(terminationStatus: 0, stdout: data, stderr: Data())
     }
 
     private func success(_ text: String = "") -> CommandOutput {

--- a/Tests/XcodeSimulatorHostTests/TestSupport.swift
+++ b/Tests/XcodeSimulatorHostTests/TestSupport.swift
@@ -273,6 +273,10 @@ struct InstallationFixture {
     static func makeLegacyXcode(at url: URL, version: String, build: String) throws {
         try makeXcodeBase(at: url, version: version, build: build)
 
+        let versionComponents = try ToolVersion(version).components
+        let minor = versionComponents.count > 1 ? versionComponents[1] : 0
+        let dtXcode = versionComponents[0] * 100 + minor * 10
+
         let simulatorURL = url.appendingPathComponent(ToolConstants.simulatorPath, isDirectory: true)
         try writePropertyList(
             [
@@ -280,6 +284,7 @@ struct InstallationFixture {
                 "CFBundleExecutable": "Simulator",
                 "CFBundleShortVersionString": "16.0",
                 "CFBundleVersion": "1063.4",
+                "DTXcode": String(dtXcode),
             ],
             to: simulatorURL.appendingPathComponent("Contents/Info.plist")
         )

--- a/Tests/XcodeSimulatorHostTests/TestSupport.swift
+++ b/Tests/XcodeSimulatorHostTests/TestSupport.swift
@@ -1,0 +1,378 @@
+import Foundation
+import Testing
+
+@testable import XcodeSimulatorHost
+
+extension CodeSignatureValidator {
+    static let acceptingTestFixtures = CodeSignatureValidator { _, _ in }
+}
+
+final class TemporaryTestDirectory {
+    let url: URL
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) throws {
+        self.fileManager = fileManager
+        url = fileManager.temporaryDirectory
+            .appendingPathComponent("\(ToolConstants.name)-tests-\(UUID().uuidString)")
+        try fileManager.createDirectory(at: url, withIntermediateDirectories: false)
+    }
+
+    deinit {
+        try? fileManager.removeItem(at: url)
+    }
+}
+
+final class FakeSystemCommandRunner: CommandRunning {
+    struct Call: Equatable {
+        let executable: URL
+        let arguments: [String]
+    }
+
+    enum FailureTiming {
+        case beforeMutation
+        case afterMutation
+    }
+
+    var domains: [String: [String: Any]] = [:]
+    var selectedDeveloperDirectory: URL?
+    var failMutationNumbers: Set<Int> = []
+    var failExportNumber: Int?
+    var failureTiming: FailureTiming = .beforeMutation
+    var beforeRun: ((Call) -> Void)?
+    private(set) var calls: [Call] = []
+    private(set) var mutationCount = 0
+    private var exportCount = 0
+
+    func run(executable: URL, arguments: [String]) throws -> CommandOutput {
+        let call = Call(executable: executable, arguments: arguments)
+        calls.append(call)
+        beforeRun?(call)
+
+        switch executable.path {
+        case "/usr/bin/defaults":
+            return try runDefaults(arguments)
+        case "/usr/bin/xcode-select":
+            guard arguments == ["-p"], let selectedDeveloperDirectory else {
+                return failure("no selected developer directory")
+            }
+            return success("\(selectedDeveloperDirectory.path)\n")
+        default:
+            throw CLIError.software(
+                "unexpected-test-command",
+                "unexpected command: \(executable.path) \(arguments)"
+            )
+        }
+    }
+
+    func storedBoolean(_ preference: ManagedPreference) -> StoredBoolean {
+        guard let raw = domains[preference.domain]?[preference.key] else {
+            return .absent
+        }
+        return StoredBoolean((raw as? NSNumber)?.boolValue ?? false)
+    }
+
+    func setStoredValue(_ value: Any?, for preference: ManagedPreference) {
+        if let value {
+            domains[preference.domain, default: [:]][preference.key] = value
+        } else {
+            domains[preference.domain]?[preference.key] = nil
+        }
+    }
+
+    private func runDefaults(_ arguments: [String]) throws -> CommandOutput {
+        guard let operation = arguments.first else {
+            return failure("missing defaults operation")
+        }
+
+        switch operation {
+        case "export":
+            guard arguments.count == 3, arguments[2] == "-" else {
+                return failure("invalid export arguments")
+            }
+            exportCount += 1
+            if failExportNumber == exportCount {
+                return failure("injected export failure")
+            }
+            let domain = domains[arguments[1], default: [:]]
+            let data = try PropertyListSerialization.data(
+                fromPropertyList: domain,
+                format: .xml,
+                options: 0
+            )
+            return CommandOutput(terminationStatus: 0, stdout: data, stderr: Data())
+
+        case "write":
+            guard arguments.count == 5, arguments[3] == "-bool" else {
+                return failure("invalid write arguments")
+            }
+            mutationCount += 1
+            if failMutationNumbers.contains(mutationCount), failureTiming == .beforeMutation {
+                return failure("injected write failure")
+            }
+            domains[arguments[1], default: [:]][arguments[2]] = arguments[4] == "true"
+            if failMutationNumbers.contains(mutationCount), failureTiming == .afterMutation {
+                return failure("injected post-write failure")
+            }
+            return success()
+
+        case "delete":
+            guard arguments.count == 3 else {
+                return failure("invalid delete arguments")
+            }
+            mutationCount += 1
+            if failMutationNumbers.contains(mutationCount), failureTiming == .beforeMutation {
+                return failure("injected delete failure")
+            }
+            domains[arguments[1]]?[arguments[2]] = nil
+            if failMutationNumbers.contains(mutationCount), failureTiming == .afterMutation {
+                return failure("injected post-delete failure")
+            }
+            return success()
+
+        default:
+            return failure("unexpected defaults operation")
+        }
+    }
+
+    private func success(_ text: String = "") -> CommandOutput {
+        CommandOutput(
+            terminationStatus: 0,
+            stdout: Data(text.utf8),
+            stderr: Data()
+        )
+    }
+
+    private func failure(_ text: String) -> CommandOutput {
+        CommandOutput(
+            terminationStatus: 1,
+            stdout: Data(),
+            stderr: Data(text.utf8)
+        )
+    }
+}
+
+@MainActor
+final class WorkspaceRecorder {
+    var runningXcodes: [RunningApplication] = []
+    var openedApplications: [URL] = []
+    var openError: (any Error)?
+
+    var client: WorkspaceClient {
+        WorkspaceClient(
+            runningXcodes: { self.runningXcodes },
+            openApplication: { url in
+                self.openedApplications.append(url)
+                if let openError = self.openError {
+                    throw openError
+                }
+                return url
+            }
+        )
+    }
+}
+
+struct InstallationFixture {
+    let directory: TemporaryTestDirectory
+    let applicationsURL: URL
+    let targetXcodeURL: URL
+    let legacyXcodeURL: URL
+
+    init(
+        targetVersion: String = "27.0",
+        targetBuild: String = "27A5252f",
+        includeHiddenKey: Bool = true,
+        includeDeviceHubKey: Bool = true,
+        legacyVersions: [(String, String, String)] = [
+            ("Xcode.app", "26.6", "17F109"),
+        ]
+    ) throws {
+        directory = try TemporaryTestDirectory()
+        applicationsURL = directory.url.appendingPathComponent("Applications", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: applicationsURL,
+            withIntermediateDirectories: false
+        )
+
+        targetXcodeURL = applicationsURL.appendingPathComponent("Xcode_27.app", isDirectory: true)
+        try Self.makeTargetXcode(
+            at: targetXcodeURL,
+            version: targetVersion,
+            build: targetBuild,
+            includeHiddenKey: includeHiddenKey,
+            includeDeviceHubKey: includeDeviceHubKey
+        )
+
+        var legacyURLs: [URL] = []
+        for entry in legacyVersions {
+            let url = applicationsURL.appendingPathComponent(entry.0, isDirectory: true)
+            try Self.makeLegacyXcode(at: url, version: entry.1, build: entry.2)
+            legacyURLs.append(url)
+        }
+        guard let first = legacyURLs.first else {
+            throw CLIError.software("test-fixture", "legacy fixture requires one Xcode")
+        }
+        legacyXcodeURL = first
+    }
+
+    var developerDirectoryURL: URL {
+        targetXcodeURL.appendingPathComponent("Contents/Developer", isDirectory: true)
+    }
+
+    static func makeTargetXcode(
+        at url: URL,
+        version: String,
+        build: String,
+        includeHiddenKey: Bool,
+        includeDeviceHubKey: Bool
+    ) throws {
+        try makeXcodeBase(at: url, version: version, build: build)
+
+        let deviceHubURL = url.appendingPathComponent(ToolConstants.deviceHubPath, isDirectory: true)
+        try writePropertyList(
+            [
+                "CFBundleIdentifier": ToolConstants.deviceHubBundleIdentifier,
+                "CFBundleExecutable": "DevicesTrampoline",
+            ],
+            to: deviceHubURL.appendingPathComponent("Contents/Info.plist")
+        )
+        let deviceHubExecutableURL = deviceHubURL
+            .appendingPathComponent("Contents/MacOS", isDirectory: true)
+            .appendingPathComponent("DevicesTrampoline")
+        try FileManager.default.createDirectory(
+            at: deviceHubExecutableURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("fixture".utf8).write(to: deviceHubExecutableURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: deviceHubExecutableURL.path
+        )
+        let deviceHubImplementationURL = deviceHubURL
+            .appendingPathComponent(ToolConstants.deviceHubImplementationPath)
+        let deviceHubContent = includeDeviceHubKey
+            ? "prefix\(ToolConstants.deviceHubPreference.key)suffix"
+            : "missing-key"
+        try Data(deviceHubContent.utf8).write(to: deviceHubImplementationURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: deviceHubImplementationURL.path
+        )
+
+        let binaryURL = url.appendingPathComponent(ToolConstants.ideIOSSupportCorePath)
+        try FileManager.default.createDirectory(
+            at: binaryURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let content = includeHiddenKey
+            ? "prefix\(ToolConstants.xcodePreference.key)suffix"
+            : "missing-key"
+        try Data(content.utf8).write(to: binaryURL)
+    }
+
+    static func makeLegacyXcode(at url: URL, version: String, build: String) throws {
+        try makeXcodeBase(at: url, version: version, build: build)
+
+        let simulatorURL = url.appendingPathComponent(ToolConstants.simulatorPath, isDirectory: true)
+        try writePropertyList(
+            [
+                "CFBundleIdentifier": ToolConstants.simulatorBundleIdentifier,
+                "CFBundleExecutable": "Simulator",
+                "CFBundleShortVersionString": "16.0",
+                "CFBundleVersion": "1063.4",
+            ],
+            to: simulatorURL.appendingPathComponent("Contents/Info.plist")
+        )
+        let executableURL = simulatorURL.appendingPathComponent("Contents/MacOS/Simulator")
+        try FileManager.default.createDirectory(
+            at: executableURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("fixture".utf8).write(to: executableURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: executableURL.path
+        )
+    }
+
+    private static func makeXcodeBase(at url: URL, version: String, build: String) throws {
+        try writePropertyList(
+            [
+                "CFBundleIdentifier": ToolConstants.xcodeBundleIdentifier,
+                "CFBundleShortVersionString": version,
+            ],
+            to: url.appendingPathComponent("Contents/Info.plist")
+        )
+        try writePropertyList(
+            ["ProductBuildVersion": build],
+            to: url.appendingPathComponent("Contents/version.plist")
+        )
+        try FileManager.default.createDirectory(
+            at: url.appendingPathComponent("Contents/Developer", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+    }
+
+    private static func writePropertyList(_ object: Any, to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: object,
+            format: .xml,
+            options: 0
+        )
+        try data.write(to: url)
+    }
+}
+
+@MainActor
+struct ControllerFixture {
+    let installations: InstallationFixture
+    let stateDirectory: TemporaryTestDirectory
+    let runner: FakeSystemCommandRunner
+    let workspace: WorkspaceRecorder
+    let receiptStore: ReceiptStore
+    let controller: HostModeController
+
+    init(
+        initialState: ManagedPreferenceState = .deviceHub,
+        targetVersion: String = "27.0",
+        includeHiddenKey: Bool = true,
+        effectiveUserID: uid_t = 501
+    ) throws {
+        installations = try InstallationFixture(
+            targetVersion: targetVersion,
+            includeHiddenKey: includeHiddenKey
+        )
+        stateDirectory = try TemporaryTestDirectory()
+        runner = FakeSystemCommandRunner()
+        runner.selectedDeveloperDirectory = installations.developerDirectoryURL
+        runner.setStoredValue(
+            initialState.xcodeSession.booleanValue,
+            for: ToolConstants.xcodePreference
+        )
+        runner.setStoredValue(
+            initialState.deviceHubAutoStartSuppression.booleanValue,
+            for: ToolConstants.deviceHubPreference
+        )
+        workspace = WorkspaceRecorder()
+        receiptStore = try ReceiptStore(directoryURL: stateDirectory.url)
+
+        let inspector = InstallationInspector(
+            runner: runner,
+            environment: ["DEVELOPER_DIR": installations.developerDirectoryURL.path],
+            legacySearchRoots: [installations.applicationsURL],
+            signatureValidator: .acceptingTestFixtures
+        )
+        controller = HostModeController(
+            defaultsStore: DefaultsStore(runner: runner),
+            receiptStore: receiptStore,
+            installationInspector: inspector,
+            workspace: workspace.client,
+            now: { Date(timeIntervalSince1970: 1_800_000_000) },
+            effectiveUserID: effectiveUserID
+        )
+    }
+}

--- a/Tests/xcode_simulator_hostTests/xcode_simulator_hostTests.swift
+++ b/Tests/xcode_simulator_hostTests/xcode_simulator_hostTests.swift
@@ -1,8 +1,0 @@
-import Testing
-@testable import xcode_simulator_host
-
-@Test func example() async throws {
-    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
-    // Swift Testing Documentation
-    // https://developer.apple.com/documentation/testing
-}

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build-release.sh --version <tag> [--dist-root <dir>]
+
+Builds the arm64 release binary and stages it under:
+  <dist-root>/arm64/bin/
+EOF
+}
+
+version=""
+dist_root="dist"
+arch="arm64"
+product="xcode-simulator-host"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --dist-root)
+      dist_root="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! "$version" =~ ^v[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+  echo "Release tag must look like v1.2.3 or v1.2.3-rc.1." >&2
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ "$dist_root" = /* ]]; then
+  dist_base="$dist_root"
+else
+  dist_base="$repo_root/$dist_root"
+fi
+
+out_dir="$dist_base/$arch"
+bin_out="$out_dir/bin"
+
+pushd "$repo_root" >/dev/null
+
+swift build -c release --arch "$arch" --product "$product"
+bin_path="$(swift build -c release --arch "$arch" --show-bin-path)"
+source_path="$bin_path/$product"
+if [[ ! -f "$source_path" ]]; then
+  echo "Failed to locate built binary: $source_path" >&2
+  exit 1
+fi
+
+actual_version="$("$source_path" --version)"
+expected_version="${version#v}"
+if [[ "$actual_version" != "$expected_version" ]]; then
+  echo "Binary version does not match release tag." >&2
+  echo "Expected: $expected_version" >&2
+  echo "Actual:   $actual_version" >&2
+  exit 1
+fi
+
+rm -rf "$out_dir"
+mkdir -p "$bin_out"
+target_path="$bin_out/$product"
+cp "$source_path" "$target_path"
+chmod +x "$target_path"
+
+if command -v lipo >/dev/null 2>&1; then
+  archs="$(lipo -archs "$target_path")"
+  if [[ "$archs" != "$arch" ]]; then
+    echo "Expected $arch binary for $product, got: $archs" >&2
+    exit 1
+  fi
+fi
+
+if command -v codesign >/dev/null 2>&1; then
+  codesign --force --sign - "$target_path" >/dev/null
+fi
+
+popd >/dev/null
+
+echo "Staged release binary at: $target_path"

--- a/scripts/install-release.sh.in
+++ b/scripts/install-release.sh.in
@@ -1,0 +1,115 @@
+#!/usr/bin/env sh
+set -eu
+
+VERSION="__VERSION__"
+REPO="__REPO__"
+DEFAULT_BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+BASE_URL="${XCODE_SIMULATOR_HOST_BASE_URL:-$DEFAULT_BASE_URL}"
+PREFIX="${PREFIX:-${HOME}/.local}"
+BINDIR="${BINDIR:-}"
+ARCHIVE="xcode-simulator-host-darwin-arm64.tar.gz"
+
+usage() {
+  cat <<'EOF'
+Usage: install.sh [--prefix <dir>] [--bindir <dir>]
+EOF
+}
+
+need_value() {
+  if [ -z "${2:-}" ]; then
+    echo "$1 requires a value." >&2
+    usage >&2
+    exit 1
+  fi
+}
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --prefix)
+      need_value "$1" "${2:-}"
+      PREFIX="$2"
+      shift 2
+      ;;
+    --bindir)
+      need_value "$1" "${2:-}"
+      BINDIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+need curl
+need grep
+need install
+need mktemp
+need shasum
+need tar
+need uname
+
+if [ -z "$BINDIR" ]; then
+  BINDIR="${PREFIX}/bin"
+fi
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+if [ "$OS" != "Darwin" ]; then
+  echo "GitHub release archives are macOS arm64 only. Build from source on ${OS}/${ARCH}." >&2
+  exit 1
+fi
+
+ARM64_CAPABLE=0
+if [ "$ARCH" = "arm64" ]; then
+  ARM64_CAPABLE=1
+elif [ "$(sysctl -n hw.optional.arm64 2>/dev/null || echo 0)" = "1" ]; then
+  ARM64_CAPABLE=1
+fi
+
+if [ "$ARM64_CAPABLE" != "1" ]; then
+  echo "GitHub release archives are macOS arm64 only. Build from source on ${OS}/${ARCH}." >&2
+  exit 1
+fi
+
+tmp_root="${TMPDIR:-/tmp}"
+tmp_dir="$(mktemp -d "${tmp_root%/}/xcode-simulator-host.XXXXXX")"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+curl -fsSL -o "$tmp_dir/$ARCHIVE" "$BASE_URL/$ARCHIVE"
+curl -fsSL -o "$tmp_dir/SHA256SUMS.txt" "$BASE_URL/SHA256SUMS.txt"
+
+(
+  cd "$tmp_dir"
+  grep "  ${ARCHIVE}\$" SHA256SUMS.txt > SHA256SUMS.selected
+  shasum -a 256 -c SHA256SUMS.selected
+  tar -xzf "$ARCHIVE"
+)
+
+mkdir -p "$BINDIR"
+install -m 755 "$tmp_dir/bin/xcode-simulator-host" "$BINDIR/xcode-simulator-host"
+
+echo "Installed xcode-simulator-host ${VERSION} to ${BINDIR}"
+case ":${PATH}:" in
+  *":${BINDIR}:"*) ;;
+  *)
+    echo "Add this directory to PATH:"
+    echo "  export PATH=\"${BINDIR}:\$PATH\""
+    ;;
+esac

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/package-release.sh --version <tag> [--repo <owner/repo>] [--dist-root <dir>] [--output-dir <dir>]
+
+Requires:
+  <dist-root>/arm64/bin/xcode-simulator-host
+
+Outputs:
+  <output-dir>/xcode-simulator-host-darwin-arm64.tar.gz
+  <output-dir>/SHA256SUMS.txt
+  <output-dir>/install.sh
+EOF
+}
+
+version=""
+release_repo="lynnswap/xcode-simulator-host"
+dist_root="dist"
+output_dir="release"
+archive_name="xcode-simulator-host-darwin-arm64.tar.gz"
+product="xcode-simulator-host"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      release_repo="${2:-}"
+      shift 2
+      ;;
+    --dist-root)
+      dist_root="${2:-}"
+      shift 2
+      ;;
+    --output-dir)
+      output_dir="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! "$version" =~ ^v[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+  echo "Release tag must look like v1.2.3 or v1.2.3-rc.1." >&2
+  exit 1
+fi
+
+if [[ ! "$release_repo" =~ ^[0-9A-Za-z_.-]+/[0-9A-Za-z_.-]+$ ]]; then
+  echo "Release repo must look like owner/repo." >&2
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ "$dist_root" = /* ]]; then
+  dist_base="$dist_root"
+else
+  dist_base="$repo_root/$dist_root"
+fi
+if [[ "$output_dir" = /* ]]; then
+  output_base="$output_dir"
+else
+  output_base="$repo_root/$output_dir"
+fi
+
+source_path="$dist_base/arm64/bin/$product"
+if [[ ! -f "$source_path" ]]; then
+  echo "Missing staged binary: $source_path" >&2
+  exit 1
+fi
+
+tmp_root="${TMPDIR:-/tmp}"
+tmp_dir="$(mktemp -d "${tmp_root%/}/xcode-simulator-host-package.XXXXXX")"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$output_base" "$tmp_dir/bin"
+archive="$output_base/$archive_name"
+install_script="$output_base/install.sh"
+rm -f "$archive" "$output_base/SHA256SUMS.txt" "$install_script"
+
+cp "$source_path" "$tmp_dir/bin/$product"
+chmod +x "$tmp_dir/bin/$product"
+if command -v lipo >/dev/null 2>&1; then
+  archs="$(lipo -archs "$tmp_dir/bin/$product")"
+  if [[ "$archs" != "arm64" ]]; then
+    echo "Expected arm64 binary for $product, got: $archs" >&2
+    exit 1
+  fi
+fi
+
+tar -C "$tmp_dir" -czf "$archive" bin
+
+"$repo_root/scripts/render-install-script.sh" \
+  --version "$version" \
+  --repo "$release_repo" \
+  --output "$install_script"
+
+(
+  cd "$output_base"
+  shasum -a 256 "$archive_name" install.sh > SHA256SUMS.txt
+)
+
+echo "Created release package: $archive"
+echo "Created checksum file: $output_base/SHA256SUMS.txt"
+echo "Created install script: $install_script"

--- a/scripts/render-install-script.sh
+++ b/scripts/render-install-script.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/render-install-script.sh --version <tag> --repo <owner/repo> --output <path>
+EOF
+}
+
+version=""
+release_repo=""
+output=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      release_repo="${2:-}"
+      shift 2
+      ;;
+    --output)
+      output="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$version" || -z "$release_repo" || -z "$output" ]]; then
+  usage >&2
+  exit 1
+fi
+
+if [[ ! "$version" =~ ^v[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+  echo "Release tag must look like v1.2.3 or v1.2.3-rc.1." >&2
+  exit 1
+fi
+
+if [[ ! "$release_repo" =~ ^[0-9A-Za-z_.-]+/[0-9A-Za-z_.-]+$ ]]; then
+  echo "Release repo must look like owner/repo." >&2
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+template="$repo_root/scripts/install-release.sh.in"
+if [[ ! -f "$template" ]]; then
+  echo "Missing installer template: $template" >&2
+  exit 1
+fi
+
+output_dir="$(dirname "$output")"
+mkdir -p "$output_dir"
+tmp_output="${output}.tmp"
+sed \
+  -e "s|__VERSION__|$version|g" \
+  -e "s|__REPO__|$release_repo|g" \
+  "$template" > "$tmp_output"
+mv "$tmp_output" "$output"
+chmod +x "$output"

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/verify-release-assets.sh --version <tag> --repo <owner/repo> [--release-dir <dir>] [--archive-sha256 <sha256>]
+EOF
+}
+
+version=""
+release_repo=""
+release_dir="release"
+archive_sha256=""
+archive_asset="xcode-simulator-host-darwin-arm64.tar.gz"
+checksum_asset="SHA256SUMS.txt"
+installer_asset="install.sh"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      release_repo="${2:-}"
+      shift 2
+      ;;
+    --release-dir)
+      release_dir="${2:-}"
+      shift 2
+      ;;
+    --archive-sha256)
+      archive_sha256="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! "$version" =~ ^v[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+  echo "Release tag must look like v1.2.3 or v1.2.3-rc.1." >&2
+  exit 1
+fi
+
+if [[ ! "$release_repo" =~ ^[0-9A-Za-z_.-]+/[0-9A-Za-z_.-]+$ ]]; then
+  echo "Release repo must look like owner/repo." >&2
+  exit 1
+fi
+
+if [[ -n "$archive_sha256" && ! "$archive_sha256" =~ ^[0-9A-Fa-f]{64}$ ]]; then
+  echo "Archive SHA256 must be a 64-character hex digest." >&2
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ "$release_dir" = /* ]]; then
+  release_base="$release_dir"
+else
+  release_base="$repo_root/$release_dir"
+fi
+
+if [[ ! -d "$release_base" ]]; then
+  echo "Missing release directory: $release_base" >&2
+  exit 1
+fi
+
+expected_assets=(
+  "$archive_asset"
+  "$checksum_asset"
+  "$installer_asset"
+)
+for asset in "${expected_assets[@]}"; do
+  if [[ ! -f "$release_base/$asset" ]]; then
+    echo "Expected release asset was not created: $asset" >&2
+    exit 1
+  fi
+done
+
+expected_asset_list="$(printf '%s\n' "${expected_assets[@]}" | sort)"
+actual_asset_list="$(
+  cd "$release_base"
+  for path in *; do
+    [[ -f "$path" ]] && printf '%s\n' "$path"
+  done | sort
+)"
+if [[ "$actual_asset_list" != "$expected_asset_list" ]]; then
+  echo "Release asset set is not expected." >&2
+  printf 'Expected:\n%s\n' "$expected_asset_list" >&2
+  printf 'Actual:\n%s\n' "$actual_asset_list" >&2
+  exit 1
+fi
+
+tmp_root="${TMPDIR:-/tmp}"
+tmp_dir="$(mktemp -d "${tmp_root%/}/xcode-simulator-host-verify.XXXXXX")"
+trap 'rm -rf "$tmp_dir"' EXIT
+expected_checksums="$tmp_dir/SHA256SUMS.expected"
+(
+  cd "$release_base"
+  shasum -a 256 "$archive_asset" "$installer_asset" > "$expected_checksums"
+)
+if ! cmp -s "$expected_checksums" "$release_base/$checksum_asset"; then
+  echo "SHA256SUMS.txt does not match the expected release assets." >&2
+  diff -u "$expected_checksums" "$release_base/$checksum_asset" || true
+  exit 1
+fi
+
+(
+  cd "$release_base"
+  shasum -a 256 -c "$checksum_asset"
+)
+
+if [[ -n "$archive_sha256" ]]; then
+  actual_archive_sha256="$(shasum -a 256 "$release_base/$archive_asset" | awk '{ print $1 }')"
+  expected_archive_sha256="$(printf '%s' "$archive_sha256" | tr 'A-F' 'a-f')"
+  if [[ "$actual_archive_sha256" != "$expected_archive_sha256" ]]; then
+    echo "Archive SHA256 does not match the trusted build output." >&2
+    echo "Expected: $expected_archive_sha256" >&2
+    echo "Actual:   $actual_archive_sha256" >&2
+    exit 1
+  fi
+fi
+
+sh -n "$release_base/$installer_asset"
+"$repo_root/scripts/render-install-script.sh" \
+  --version "$version" \
+  --repo "$release_repo" \
+  --output "$tmp_dir/install.expected.sh"
+if ! cmp -s "$tmp_dir/install.expected.sh" "$release_base/$installer_asset"; then
+  echo "install.sh does not match the generated installer for $version." >&2
+  diff -u "$tmp_dir/install.expected.sh" "$release_base/$installer_asset" || true
+  exit 1
+fi
+
+expected_entries="$(printf '%s\n' \
+  "bin/" \
+  "bin/xcode-simulator-host")"
+actual_entries="$(tar -tzf "$release_base/$archive_asset" | sort)"
+if [[ "$actual_entries" != "$expected_entries" ]]; then
+  echo "Release archive contents are not expected." >&2
+  printf 'Expected:\n%s\n' "$expected_entries" >&2
+  printf 'Actual:\n%s\n' "$actual_entries" >&2
+  exit 1
+fi
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  install_root="$tmp_dir/install-root"
+  extracted_root="$tmp_dir/extracted"
+  mkdir -p "$extracted_root"
+  XCODE_SIMULATOR_HOST_BASE_URL="file://$release_base" \
+    sh "$release_base/$installer_asset" --bindir "$install_root/bin"
+  tar -C "$extracted_root" -xzf "$release_base/$archive_asset"
+  cmp -s \
+    "$install_root/bin/xcode-simulator-host" \
+    "$extracted_root/bin/xcode-simulator-host"
+  installed_version="$("$install_root/bin/xcode-simulator-host" --version)"
+  if [[ "$installed_version" != "${version#v}" ]]; then
+    echo "Installed binary version does not match release tag." >&2
+    echo "Expected: ${version#v}" >&2
+    echo "Actual:   $installed_version" >&2
+    exit 1
+  fi
+fi


### PR DESCRIPTION
## Purpose

Xcode 27 routes GUI simulator runs through Device Hub, which can be unstable. This adds an experimental, reversible CLI for selecting the classic Xcode 26 Simulator route while Xcode remains open, then returning to Device Hub or restoring the exact original preferences.

The behavior relies on undocumented Xcode preferences, so support is intentionally limited to installations that match the verified Xcode 27 compatibility markers.

## Changes

- Add a Swift Argument Parser CLI with status, use legacy, use device-hub, and restore commands.
- Store the original tri-state preferences in a recovery receipt, serialize mutations, verify read-back, roll back failed writes, and stop on ambiguous or external changes.
- Treat missing defaults domains as absent without masking export failures for existing domains, and bracket every individual preference write with full-state verification shared by forward transitions and rollback.
- Validate the selected Xcode 27 layout and hidden keys, and require Apple-signed Xcode 26 and Simulator bundles with matching signed generation metadata for the legacy route.
- Hold one operation lock across preference commit, Device Hub termination, final mode verification, and Simulator launch; serialize restore before receipt capture while keeping fresh read-only status and no-op restore free of state artifacts.
- Reconcile a live switch by normally terminating only the exact Device Hub inside the selected Xcode and opening the validated legacy Simulator without restarting Xcode.
- Add arm64 release packaging, checksum verification, a one-line installer, CI, and manually published draft-release automation with external Actions pinned to full commit SHAs.
- Add the MIT license, an English quick-start README, and the detailed design and safety contract.

## Review focus

- The compatibility gate for undocumented Xcode 27 behavior and the fail-closed handling of unknown installations.
- Receipt ownership, guarded per-write preference transitions, rollback/conflict detection, and the documented lack of an atomic compare-and-swap in defaults.
- Device Hub process identity and the operation-lock boundary across every preference and process-lifecycle side effect.
- The optimistic read-only status snapshot, monotonic state-directory marker, and serialized restore fast path.
- Initial release asset validation and the manual publication boundary.

## Testing

- swift test — 65 tests across 5 suites on Xcode 27 / Swift 6.4.
- The [PR CI run](https://github.com/lynnswap/xcode-simulator-host/actions/runs/33127308875) passed on the xcode-27-arm64 image with Xcode 27.0 / Swift 6.4, including all 65 tests, the release product build, and distribution-script validation.
- A live read-only status check validated the selected Xcode 27, absent/absent preferences, the Xcode 26 Simulator, and no restoration receipt.
- Live A/B test with the same Xcode 27 process kept open: Device Hub route to the Xcode 26 Simulator route and back, including demo launch and restoration of the original preferences and simulator state.
- scripts/verify-release-assets.sh --version v0.1.0 --repo lynnswap/xcode-simulator-host --release-dir release — checksums, archive contents, rendered installer, and an isolated install all passed.
- actionlint, shellcheck, script syntax checks, and git diff --check passed.
- All external GitHub Actions references are full-SHA pinned; their annotated versions resolve to those SHAs and use the Node 24 runtime.
- Branch-wide codex-review against the pinned main base completed with 0 findings.

No GitHub release was published as part of this PR; the one-line installer becomes available after the first release is published. No screenshots are included because this change adds a command-line tool and does not modify a graphical interface.
