### PR TITLE
Prepare v0.0.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ curl -fsSL https://github.com/lynnswap/xcode-simulator-host/releases/latest/down
 Install a specific version:
 
 ```bash
-curl -fsSL https://github.com/lynnswap/xcode-simulator-host/releases/download/v0.1.0/install.sh | sh
+curl -fsSL https://github.com/lynnswap/xcode-simulator-host/releases/download/v0.0.1/install.sh | sh
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -69,18 +69,12 @@ preference domain.
 ## Install Options
 
 <details>
-<summary>Custom directory or pinned version</summary>
+<summary>Custom install directory</summary>
 
 Install into a custom directory:
 
 ```bash
 curl -fsSL https://github.com/lynnswap/xcode-simulator-host/releases/latest/download/install.sh | sh -s -- --bindir "$HOME/bin"
-```
-
-Install a specific version:
-
-```bash
-curl -fsSL https://github.com/lynnswap/xcode-simulator-host/releases/download/v0.0.1/install.sh | sh
 ```
 
 </details>

--- a/Sources/XcodeSimulatorHost/ToolConstants.swift
+++ b/Sources/XcodeSimulatorHost/ToolConstants.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum ToolConstants {
     static let name = "xcode-simulator-host"
-    static let version = "0.1.0"
+    static let version = "0.0.1"
 
     static let supportedXcodeMajorVersion = 27
     static let legacyXcodeMajorVersion = 26


### PR DESCRIPTION
## Purpose

Prepare the repository for its first published release, v0.0.1. The release workflow verifies that the requested tag matches the executable version, so main must expose 0.0.1 before the Model B release workflow can be dispatched.

User-facing install commands should not require documentation edits for every release. They therefore resolve the latest published release instead of embedding a version.

## Changes

- Change the executable version from 0.1.0 to 0.0.1.
- Remove the pinned-version installer example so every README release-install command uses releases/latest.

## Testing

- swift test — 65 tests across 5 suites passed with Xcode 27 / Swift 6.4.
- scripts/build-release.sh, scripts/package-release.sh, and scripts/verify-release-assets.sh completed for v0.0.1.
- The generated arm64 archive, checksums, installer rendering, isolated installation, and installed binary version were verified.
- Every user-facing GitHub Release curl command in README.md resolves releases/latest.
- actionlint and git diff --check passed.
- Branch-wide codex-review against main completed with 0 findings.

No screenshots are included because this only aligns release metadata and installation documentation.
