### PR TITLE
Show only the active simulator route by default

### DIFF
--- a/Documentation/AdvancedConfiguration.md
+++ b/Documentation/AdvancedConfiguration.md
@@ -1,0 +1,64 @@
+# Advanced configuration
+
+The default workflow does not require any of these options. Use them only when
+you need diagnostic details or an Xcode installation outside the normal
+selection paths.
+
+## Detailed status
+
+The default status reports only the route used by the next Xcode Run:
+
+```console
+xcode-simulator-host status
+```
+
+Add `--verbose` to inspect the resolved Xcode installations, managed
+preferences, restoration state, and running Xcode processes:
+
+```console
+xcode-simulator-host status --verbose
+```
+
+## Xcode 27 installation
+
+Commands that validate Xcode 27 use `DEVELOPER_DIR` when it is set and
+otherwise use `xcode-select -p`. To inspect a non-default installation:
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode_27.app/Contents/Developer \
+  xcode-simulator-host status --verbose
+```
+
+Set the same environment variable on a mutation command to use that
+installation for validation and Device Hub management:
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode_27.app/Contents/Developer \
+  xcode-simulator-host use legacy
+```
+
+## Xcode 26 Simulator
+
+`use legacy` normally selects the newest validated Xcode 26 installation in
+`/Applications`. Pass an absolute path when the installation is elsewhere:
+
+```bash
+xcode-simulator-host use legacy \
+  --legacy-xcode /Applications/Xcode_26.app
+```
+
+The same override can be used with detailed status:
+
+```bash
+xcode-simulator-host status --verbose \
+  --legacy-xcode /Applications/Xcode_26.app
+```
+
+## Preference scope
+
+The managed Xcode preferences are shared by all installed Xcode versions.
+Selecting an installation changes which Xcode and Device Hub are validated; it
+does not create a separate preference state for that installation.
+
+See the [design and safety contract](Design.md) for compatibility checks,
+transaction ownership, recovery behavior, and exit codes.

--- a/Documentation/Design.md
+++ b/Documentation/Design.md
@@ -6,13 +6,15 @@
 used alongside Xcode 27 simulator runs.
 
 ```console
-xcode-simulator-host status
+xcode-simulator-host status [--verbose]
 xcode-simulator-host use legacy [--legacy-xcode /Applications/Xcode.app]
 xcode-simulator-host use device-hub
 xcode-simulator-host restore [--force]
 ```
 
-- `status` is read-only.
+- `status` is read-only. Its default output is only the simulator route used by
+  the next Run; `--verbose` adds installations, preferences, restoration state,
+  and running processes.
 - `use legacy` configures Xcode for a CoreSimulator-only session, prevents an
   already-running Device Hub from automatically starting a live view, normally
   terminates the verified Device Hub, and opens the validated Simulator app

--- a/Documentation/Design.md
+++ b/Documentation/Design.md
@@ -14,7 +14,9 @@ xcode-simulator-host restore [--force]
 
 - `status` is read-only. Its default output is only the simulator route used by
   the next Run; `--verbose` adds installations, preferences, restoration state,
-  and running processes.
+  and running processes. The default path reads only managed preferences and
+  restoration state, so reporting the route does not depend on Xcode discovery
+  or installation validation.
 - `use legacy` configures Xcode for a CoreSimulator-only session, prevents an
   already-running Device Hub from automatically starting a live view, normally
   terminates the verified Device Hub, and opens the validated Simulator app

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ xcode-simulator-host status
 xcode-simulator-host use legacy
 ```
 
+`status` prints only the simulator route used by the next Run. Use
+`xcode-simulator-host status --verbose` for Xcode installations, preferences,
+restoration state, and running processes.
+
 Leave Xcode 27 open. After the command opens Simulator, use **Build & Run** in
 Xcode as usual.
 

--- a/README.md
+++ b/README.md
@@ -48,28 +48,6 @@ xcode-simulator-host restore
 `restore` instead preserves whether each original preference was absent,
 explicitly `false`, or explicitly `true`.
 
-## Selecting Xcode Installations
-
-The Xcode 27 installation comes from `DEVELOPER_DIR`, or from `xcode-select -p`
-when `DEVELOPER_DIR` is unset:
-
-```bash
-DEVELOPER_DIR=/Applications/Xcode_27.app/Contents/Developer \
-  xcode-simulator-host status --verbose
-```
-
-`use legacy` selects the newest validated Xcode 26 in `/Applications`. Pass an
-absolute path when the installation is elsewhere:
-
-```bash
-xcode-simulator-host use legacy \
-  --legacy-xcode /Applications/Xcode_26.app
-```
-
-The managed Xcode preference is shared by all installed Xcode versions. The
-selected Xcode 27 determines which installation is validated, not a separate
-preference domain.
-
 ## Install Options
 
 <details>

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ when `DEVELOPER_DIR` is unset:
 
 ```bash
 DEVELOPER_DIR=/Applications/Xcode_27.app/Contents/Developer \
-  xcode-simulator-host status
+  xcode-simulator-host status --verbose
 ```
 
 `use legacy` selects the newest validated Xcode 26 in `/Applications`. Pass an

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ curl -fsSL https://github.com/lynnswap/xcode-simulator-host/releases/latest/down
 
 The installer verifies the release checksum and never edits shell profiles.
 Use `xcode-simulator-host --help` for the complete command and option list.
+See [Advanced configuration](Documentation/AdvancedConfiguration.md) for
+detailed diagnostics and non-default Xcode installations.
 
 ## Safety and Recovery
 

--- a/Sources/XcodeSimulatorHost/CommandLine/XcodeSimulatorHostApplication.swift
+++ b/Sources/XcodeSimulatorHost/CommandLine/XcodeSimulatorHostApplication.swift
@@ -21,12 +21,19 @@ struct XcodeSimulatorHostApplication {
 
     func run(_ command: XcodeSimulatorHostCommand) async throws -> (String, Int32) {
         switch command {
-        case .status(let legacyXcode, let verbose):
-            let status = try controller.status(explicitLegacyXcodeURL: legacyXcode)
+        case .status(.compact):
+            let status = try controller.routeStatus()
             let exitCode = status.receiptStatus.hasConflict
                 ? CLIError.Category.configuration.rawValue
                 : 0
-            return (verbose ? status.rendered : status.compactRendered, exitCode)
+            return (status.rendered, exitCode)
+
+        case .status(.verbose(let legacyXcode)):
+            let status = try controller.status(explicitLegacyXcodeURL: legacyXcode)
+            let exitCode = status.routeStatus.receiptStatus.hasConflict
+                ? CLIError.Category.configuration.rawValue
+                : 0
+            return (status.rendered, exitCode)
 
         case .use(let mode, let legacyXcode):
             let report = try await controller.use(

--- a/Sources/XcodeSimulatorHost/CommandLine/XcodeSimulatorHostApplication.swift
+++ b/Sources/XcodeSimulatorHost/CommandLine/XcodeSimulatorHostApplication.swift
@@ -21,12 +21,12 @@ struct XcodeSimulatorHostApplication {
 
     func run(_ command: XcodeSimulatorHostCommand) async throws -> (String, Int32) {
         switch command {
-        case .status(let legacyXcode):
+        case .status(let legacyXcode, let verbose):
             let status = try controller.status(explicitLegacyXcodeURL: legacyXcode)
             let exitCode = status.receiptStatus.hasConflict
                 ? CLIError.Category.configuration.rawValue
                 : 0
-            return (status.rendered, exitCode)
+            return (verbose ? status.rendered : status.compactRendered, exitCode)
 
         case .use(let mode, let legacyXcode):
             let report = try await controller.use(

--- a/Sources/XcodeSimulatorHost/CommandLine/XcodeSimulatorHostArguments.swift
+++ b/Sources/XcodeSimulatorHost/CommandLine/XcodeSimulatorHostArguments.swift
@@ -87,8 +87,13 @@ struct RestoreArguments: ParsableCommand {
     var force = false
 }
 
+enum StatusOutput: Equatable {
+    case compact
+    case verbose(legacyXcode: URL?)
+}
+
 enum XcodeSimulatorHostCommand: Equatable {
-    case status(legacyXcode: URL?, verbose: Bool)
+    case status(StatusOutput)
     case use(mode: HostMode, legacyXcode: URL?)
     case restore(force: Bool)
 }
@@ -97,10 +102,10 @@ func parseXcodeSimulatorHostCommand(_ arguments: [String]) throws -> XcodeSimula
     var parsed = try XcodeSimulatorHostArguments.parseAsRoot(Array(arguments.dropFirst()))
     switch parsed {
     case let command as StatusArguments:
-        return .status(
-            legacyXcode: command.legacyXcode?.url,
-            verbose: command.verbose || command.legacyXcode != nil
-        )
+        if command.verbose || command.legacyXcode != nil {
+            return .status(.verbose(legacyXcode: command.legacyXcode?.url))
+        }
+        return .status(.compact)
     case let command as UseLegacyArguments:
         return .use(mode: .legacy, legacyXcode: command.legacyXcode?.url)
     case is UseDeviceHubArguments:

--- a/Sources/XcodeSimulatorHost/CommandLine/XcodeSimulatorHostArguments.swift
+++ b/Sources/XcodeSimulatorHost/CommandLine/XcodeSimulatorHostArguments.swift
@@ -30,8 +30,13 @@ struct XcodeSimulatorHostArguments: ParsableCommand {
 struct StatusArguments: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "status",
-        abstract: "Show the selected Xcode, managed preferences, and restoration receipt."
+        abstract: "Show whether the next Run uses Device Hub or CoreSimulator."
     )
+
+    @Flag(
+        help: "Show Xcode installations, preferences, restoration state, and running processes."
+    )
+    var verbose = false
 
     @Option(
         name: .customLong("legacy-xcode"),
@@ -83,7 +88,7 @@ struct RestoreArguments: ParsableCommand {
 }
 
 enum XcodeSimulatorHostCommand: Equatable {
-    case status(legacyXcode: URL?)
+    case status(legacyXcode: URL?, verbose: Bool)
     case use(mode: HostMode, legacyXcode: URL?)
     case restore(force: Bool)
 }
@@ -92,7 +97,10 @@ func parseXcodeSimulatorHostCommand(_ arguments: [String]) throws -> XcodeSimula
     var parsed = try XcodeSimulatorHostArguments.parseAsRoot(Array(arguments.dropFirst()))
     switch parsed {
     case let command as StatusArguments:
-        return .status(legacyXcode: command.legacyXcode?.url)
+        return .status(
+            legacyXcode: command.legacyXcode?.url,
+            verbose: command.verbose || command.legacyXcode != nil
+        )
     case let command as UseLegacyArguments:
         return .use(mode: .legacy, legacyXcode: command.legacyXcode?.url)
     case is UseDeviceHubArguments:

--- a/Sources/XcodeSimulatorHost/HostModeController.swift
+++ b/Sources/XcodeSimulatorHost/HostModeController.swift
@@ -31,16 +31,28 @@ struct HostModeController {
         self.effectiveUserID = effectiveUserID
     }
 
+    func routeStatus() throws -> SimulatorRouteStatus {
+        try readStatusSnapshot {
+            try makeRouteStatus()
+        }
+    }
+
     func status(explicitLegacyXcodeURL: URL?) throws -> HostStatus {
+        try readStatusSnapshot {
+            try makeStatus(explicitLegacyXcodeURL: explicitLegacyXcodeURL)
+        }
+    }
+
+    private func readStatusSnapshot<T>(_ makeSnapshot: () throws -> T) throws -> T {
         if try !receiptStore.stateDirectoryExists() {
-            let snapshot = try makeStatus(explicitLegacyXcodeURL: explicitLegacyXcodeURL)
+            let snapshot = try makeSnapshot()
             if try !receiptStore.stateDirectoryExists() {
                 return snapshot
             }
         }
 
         return try receiptStore.withExistingExclusiveLock {
-            try makeStatus(explicitLegacyXcodeURL: explicitLegacyXcodeURL)
+            try makeSnapshot()
         }
     }
 
@@ -180,7 +192,7 @@ struct HostModeController {
 
     private func makeStatus(explicitLegacyXcodeURL: URL?) throws -> HostStatus {
         let xcode = try installationInspector.validatedTargetXcode()
-        let preferences = try defaultsStore.readState()
+        let routeStatus = try makeRouteStatus()
         let legacySimulator: SimulatorInstallation?
         if let explicitLegacyXcodeURL {
             legacySimulator = try installationInspector.legacySimulator(
@@ -191,16 +203,21 @@ struct HostModeController {
                 explicitXcodeURL: nil
             )
         }
-
-        let receipt = try receiptStore.load()
-        let receiptStatus = classify(receipt: receipt, observed: preferences)
         return HostStatus(
             xcode: xcode,
-            preferences: preferences,
+            routeStatus: routeStatus,
             legacySimulator: legacySimulator,
-            receiptStatus: receiptStatus,
             receiptURL: receiptStore.receiptURL,
             runningXcodes: workspace.runningXcodes()
+        )
+    }
+
+    private func makeRouteStatus() throws -> SimulatorRouteStatus {
+        let preferences = try defaultsStore.readState()
+        let receipt = try receiptStore.load()
+        return SimulatorRouteStatus(
+            preferences: preferences,
+            receiptStatus: classify(receipt: receipt, observed: preferences)
         )
     }
 

--- a/Sources/XcodeSimulatorHost/HostStatus.swift
+++ b/Sources/XcodeSimulatorHost/HostStatus.swift
@@ -16,15 +16,11 @@ enum ReceiptStatus: Equatable {
     }
 }
 
-struct HostStatus: Equatable {
-    let xcode: XcodeInstallation
+struct SimulatorRouteStatus: Equatable {
     let preferences: ManagedPreferenceState
-    let legacySimulator: SimulatorInstallation?
     let receiptStatus: ReceiptStatus
-    let receiptURL: URL
-    let runningXcodes: [RunningApplication]
 
-    var compactRendered: String {
+    var rendered: String {
         let route = routeLine
         switch receiptStatus {
         case .pendingBefore, .pendingTarget:
@@ -42,9 +38,26 @@ struct HostStatus: Equatable {
         }
     }
 
+    fileprivate var routeLine: String {
+        switch preferences.effectiveMode {
+        case .deviceHub:
+            "Simulator route: Device Hub"
+        case .legacy:
+            "Simulator route: CoreSimulator (Xcode 26 Simulator)"
+        }
+    }
+}
+
+struct HostStatus: Equatable {
+    let xcode: XcodeInstallation
+    let routeStatus: SimulatorRouteStatus
+    let legacySimulator: SimulatorInstallation?
+    let receiptURL: URL
+    let runningXcodes: [RunningApplication]
+
     var rendered: String {
         var lines = [
-            routeLine,
+            routeStatus.routeLine,
             "",
             "Selected Xcode: \(xcode.version) (\(xcode.buildVersion))",
             "  \(xcode.applicationURL.path)",
@@ -60,7 +73,7 @@ struct HostStatus: Equatable {
         }
 
         lines.append("")
-        switch receiptStatus {
+        switch routeStatus.receiptStatus {
         case .unmanaged:
             lines.append("Restoration receipt: none")
         case .managed(let original):
@@ -98,22 +111,13 @@ struct HostStatus: Equatable {
         lines.append("")
         lines.append("Preference details:")
         lines.append(
-            "  CoreSimulator session: \(preferences.xcodeSession.statusDescription)"
+            "  CoreSimulator session: \(routeStatus.preferences.xcodeSession.statusDescription)"
         )
         lines.append(
-            "  Suppress Device Hub auto-start: \(preferences.deviceHubAutoStartSuppression.statusDescription)"
+            "  Suppress Device Hub auto-start: \(routeStatus.preferences.deviceHubAutoStartSuppression.statusDescription)"
         )
         lines.append("  Scope: shared by all installed Xcode versions")
         return lines.joined(separator: "\n")
-    }
-
-    private var routeLine: String {
-        switch preferences.effectiveMode {
-        case .deviceHub:
-            "Simulator route: Device Hub"
-        case .legacy:
-            "Simulator route: CoreSimulator (Xcode 26 Simulator)"
-        }
     }
 }
 

--- a/Sources/XcodeSimulatorHost/HostStatus.swift
+++ b/Sources/XcodeSimulatorHost/HostStatus.swift
@@ -24,13 +24,30 @@ struct HostStatus: Equatable {
     let receiptURL: URL
     let runningXcodes: [RunningApplication]
 
+    var compactRendered: String {
+        let route = routeLine
+        switch receiptStatus {
+        case .pendingBefore, .pendingTarget:
+            return """
+                \(route)
+                Attention: an interrupted change needs recovery. Run 'xcode-simulator-host status --verbose'.
+                """
+        case .ambiguousIntermediate, .conflict:
+            return """
+                \(route)
+                Attention: preferences need review. Run 'xcode-simulator-host status --verbose'.
+                """
+        case .unmanaged, .managed:
+            return route
+        }
+    }
+
     var rendered: String {
         var lines = [
+            routeLine,
+            "",
             "Selected Xcode: \(xcode.version) (\(xcode.buildVersion))",
             "  \(xcode.applicationURL.path)",
-            "Configured host: \(preferences.effectiveMode.rawValue)",
-            "Xcode preference: \(preferences.xcodeSession)",
-            "Device Hub auto-start suppression: \(preferences.deviceHubAutoStartSuppression)",
         ]
 
         if let legacySimulator {
@@ -42,6 +59,7 @@ struct HostStatus: Equatable {
             lines.append("Legacy Simulator: not found")
         }
 
+        lines.append("")
         switch receiptStatus {
         case .unmanaged:
             lines.append("Restoration receipt: none")
@@ -66,6 +84,7 @@ struct HostStatus: Equatable {
             lines.append("  \(receiptURL.path)")
         }
 
+        lines.append("")
         if runningXcodes.isEmpty {
             lines.append("Running Xcode processes: none")
         } else {
@@ -76,8 +95,38 @@ struct HostStatus: Equatable {
             }
         }
 
-        lines.append("Note: com.apple.dt.Xcode preferences are shared by all installed Xcode versions.")
+        lines.append("")
+        lines.append("Preference details:")
+        lines.append(
+            "  CoreSimulator session: \(preferences.xcodeSession.statusDescription)"
+        )
+        lines.append(
+            "  Suppress Device Hub auto-start: \(preferences.deviceHubAutoStartSuppression.statusDescription)"
+        )
+        lines.append("  Scope: shared by all installed Xcode versions")
         return lines.joined(separator: "\n")
+    }
+
+    private var routeLine: String {
+        switch preferences.effectiveMode {
+        case .deviceHub:
+            "Simulator route: Device Hub"
+        case .legacy:
+            "Simulator route: CoreSimulator (Xcode 26 Simulator)"
+        }
+    }
+}
+
+private extension StoredBoolean {
+    var statusDescription: String {
+        switch self {
+        case .absent:
+            "not set (default)"
+        case .falseValue:
+            "false"
+        case .trueValue:
+            "true"
+        }
     }
 }
 

--- a/Tests/XcodeSimulatorHostTests/ApplicationTests.swift
+++ b/Tests/XcodeSimulatorHostTests/ApplicationTests.swift
@@ -1,0 +1,23 @@
+import Testing
+
+@testable import XcodeSimulatorHost
+
+@MainActor
+@Suite
+struct ApplicationTests {
+    @Test func compactStatusDoesNotRequireXcodeDiscovery() async throws {
+        let fixture = try ControllerFixture(initialState: .legacy)
+        fixture.runner.selectedDeveloperDirectory = nil
+        let application = XcodeSimulatorHostApplication(controller: fixture.controller)
+
+        let result = try await application.run(.status(.compact))
+
+        #expect(result.0 == "Simulator route: CoreSimulator (Xcode 26 Simulator)")
+        #expect(result.1 == 0)
+        #expect(
+            !fixture.runner.calls.contains {
+                $0.executable.path == "/usr/bin/xcode-select"
+            }
+        )
+    }
+}

--- a/Tests/XcodeSimulatorHostTests/ArgumentTests.swift
+++ b/Tests/XcodeSimulatorHostTests/ArgumentTests.swift
@@ -20,7 +20,33 @@ struct ArgumentTests {
     @Test func statusParsesWithoutAnOverride() throws {
         #expect(
             try parseXcodeSimulatorHostCommand([ToolConstants.name, "status"])
-                == .status(legacyXcode: nil)
+                == .status(legacyXcode: nil, verbose: false)
+        )
+    }
+
+    @Test func verboseStatusParses() throws {
+        #expect(
+            try parseXcodeSimulatorHostCommand([
+                ToolConstants.name, "status", "--verbose",
+            ]) == .status(legacyXcode: nil, verbose: true)
+        )
+    }
+
+    @Test func statusLegacyOverrideImpliesVerboseOutput() throws {
+        #expect(
+            try parseXcodeSimulatorHostCommand([
+                ToolConstants.name,
+                "status",
+                "--legacy-xcode",
+                "/Applications/Xcode 26.app",
+            ])
+                == .status(
+                    legacyXcode: URL(
+                        fileURLWithPath: "/Applications/Xcode 26.app",
+                        isDirectory: true
+                    ).standardizedFileURL,
+                    verbose: true
+                )
         )
     }
 

--- a/Tests/XcodeSimulatorHostTests/ArgumentTests.swift
+++ b/Tests/XcodeSimulatorHostTests/ArgumentTests.swift
@@ -20,7 +20,7 @@ struct ArgumentTests {
     @Test func statusParsesWithoutAnOverride() throws {
         #expect(
             try parseXcodeSimulatorHostCommand([ToolConstants.name, "status"])
-                == .status(legacyXcode: nil, verbose: false)
+                == .status(.compact)
         )
     }
 
@@ -28,7 +28,7 @@ struct ArgumentTests {
         #expect(
             try parseXcodeSimulatorHostCommand([
                 ToolConstants.name, "status", "--verbose",
-            ]) == .status(legacyXcode: nil, verbose: true)
+            ]) == .status(.verbose(legacyXcode: nil))
         )
     }
 
@@ -41,11 +41,10 @@ struct ArgumentTests {
                 "/Applications/Xcode 26.app",
             ])
                 == .status(
-                    legacyXcode: URL(
+                    .verbose(legacyXcode: URL(
                         fileURLWithPath: "/Applications/Xcode 26.app",
                         isDirectory: true
-                    ).standardizedFileURL,
-                    verbose: true
+                    ).standardizedFileURL)
                 )
         )
     }

--- a/Tests/XcodeSimulatorHostTests/HostModeControllerTests.swift
+++ b/Tests/XcodeSimulatorHostTests/HostModeControllerTests.swift
@@ -169,7 +169,7 @@ struct HostModeControllerTests {
         #expect(fixture.runner.storedBoolean(ToolConstants.xcodePreference) == .trueValue)
         #expect(fixture.runner.storedBoolean(ToolConstants.deviceHubPreference) == .absent)
         let status = try fixture.controller.status(explicitLegacyXcodeURL: nil)
-        #expect(status.receiptStatus == .ambiguousIntermediate)
+        #expect(status.routeStatus.receiptStatus == .ambiguousIntermediate)
     }
 
     @Test func externalPreferenceChangeIsReportedAsAConflict() async throws {
@@ -178,7 +178,7 @@ struct HostModeControllerTests {
         fixture.runner.setStoredValue(false, for: ToolConstants.xcodePreference)
 
         let status = try fixture.controller.status(explicitLegacyXcodeURL: nil)
-        #expect(status.receiptStatus.hasConflict)
+        #expect(status.routeStatus.receiptStatus.hasConflict)
 
         do {
             _ = try fixture.controller.restore()
@@ -701,7 +701,7 @@ struct HostModeControllerTests {
         ]
         let status = try fixture.controller.status(explicitLegacyXcodeURL: nil)
 
-        #expect(status.preferences == .deviceHub)
+        #expect(status.routeStatus.preferences == .deviceHub)
         #expect(status.legacySimulator != nil)
         #expect(fixture.runner.mutationCount == 0)
         #expect(try fixture.receiptStore.load() == nil)
@@ -714,7 +714,7 @@ struct HostModeControllerTests {
         #expect(!status.rendered.contains("mode changes are blocked"))
     }
 
-    @Test func statusRetriesWhenStateAppearsDuringTheOptimisticSnapshot() throws {
+    @Test func routeStatusRetriesWhenStateAppearsDuringTheOptimisticSnapshot() throws {
         let fixture = try ControllerFixture()
         var createdState = false
         fixture.runner.beforeRun = { call in
@@ -732,7 +732,7 @@ struct HostModeControllerTests {
             }
         }
 
-        let status = try fixture.controller.status(explicitLegacyXcodeURL: nil)
+        let status = try fixture.controller.routeStatus()
 
         #expect(createdState)
         #expect(status.preferences == .deviceHub)

--- a/Tests/XcodeSimulatorHostTests/HostStatusTests.swift
+++ b/Tests/XcodeSimulatorHostTests/HostStatusTests.swift
@@ -6,41 +6,41 @@ import Testing
 @Suite
 struct HostStatusTests {
     @Test func compactStatusAnswersWhichRouteTheNextRunUses() throws {
-        let deviceHub = try makeStatus(
+        let deviceHub = makeRouteStatus(
             preferences: .deviceHub,
             receiptStatus: .unmanaged
         )
-        #expect(deviceHub.compactRendered == "Simulator route: Device Hub")
+        #expect(deviceHub.rendered == "Simulator route: Device Hub")
 
-        let legacy = try makeStatus(
+        let legacy = makeRouteStatus(
             preferences: .legacy,
             receiptStatus: .managed(original: .deviceHub)
         )
         #expect(
-            legacy.compactRendered
+            legacy.rendered
                 == "Simulator route: CoreSimulator (Xcode 26 Simulator)"
         )
     }
 
     @Test func compactStatusAddsOnlyActionableSafetyWarnings() throws {
-        let pending = try makeStatus(
+        let pending = makeRouteStatus(
             preferences: .legacy,
             receiptStatus: .pendingTarget
         )
         #expect(
-            pending.compactRendered
+            pending.rendered
                 == """
                 Simulator route: CoreSimulator (Xcode 26 Simulator)
                 Attention: an interrupted change needs recovery. Run 'xcode-simulator-host status --verbose'.
                 """
         )
 
-        let conflict = try makeStatus(
+        let conflict = makeRouteStatus(
             preferences: .deviceHub,
             receiptStatus: .conflict(expected: .legacy, observed: .deviceHub)
         )
         #expect(
-            conflict.compactRendered
+            conflict.rendered
                 == """
                 Simulator route: Device Hub
                 Attention: preferences need review. Run 'xcode-simulator-host status --verbose'.
@@ -49,7 +49,7 @@ struct HostStatusTests {
     }
 
     @Test func verboseStatusStartsWithTheRouteAndKeepsTechnicalDetails() throws {
-        let status = try makeStatus(
+        let status = try makeVerboseStatus(
             preferences: .deviceHub,
             receiptStatus: .unmanaged
         )
@@ -64,7 +64,17 @@ struct HostStatusTests {
         #expect(!status.rendered.contains("Configured host:"))
     }
 
-    private func makeStatus(
+    private func makeRouteStatus(
+        preferences: ManagedPreferenceState,
+        receiptStatus: ReceiptStatus
+    ) -> SimulatorRouteStatus {
+        SimulatorRouteStatus(
+            preferences: preferences,
+            receiptStatus: receiptStatus
+        )
+    }
+
+    private func makeVerboseStatus(
         preferences: ManagedPreferenceState,
         receiptStatus: ReceiptStatus
     ) throws -> HostStatus {
@@ -80,7 +90,10 @@ struct HostStatusTests {
         )
         return HostStatus(
             xcode: selectedXcode,
-            preferences: preferences,
+            routeStatus: SimulatorRouteStatus(
+                preferences: preferences,
+                receiptStatus: receiptStatus
+            ),
             legacySimulator: SimulatorInstallation(
                 applicationURL: URL(
                     fileURLWithPath: "/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app"
@@ -89,7 +102,6 @@ struct HostStatusTests {
                 version: "16.0",
                 buildVersion: "1063.4"
             ),
-            receiptStatus: receiptStatus,
             receiptURL: URL(
                 fileURLWithPath: "/Users/test/Library/Application Support/xcode-simulator-host/state.plist"
             ),

--- a/Tests/XcodeSimulatorHostTests/HostStatusTests.swift
+++ b/Tests/XcodeSimulatorHostTests/HostStatusTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Testing
+
+@testable import XcodeSimulatorHost
+
+@Suite
+struct HostStatusTests {
+    @Test func compactStatusAnswersWhichRouteTheNextRunUses() throws {
+        let deviceHub = try makeStatus(
+            preferences: .deviceHub,
+            receiptStatus: .unmanaged
+        )
+        #expect(deviceHub.compactRendered == "Simulator route: Device Hub")
+
+        let legacy = try makeStatus(
+            preferences: .legacy,
+            receiptStatus: .managed(original: .deviceHub)
+        )
+        #expect(
+            legacy.compactRendered
+                == "Simulator route: CoreSimulator (Xcode 26 Simulator)"
+        )
+    }
+
+    @Test func compactStatusAddsOnlyActionableSafetyWarnings() throws {
+        let pending = try makeStatus(
+            preferences: .legacy,
+            receiptStatus: .pendingTarget
+        )
+        #expect(
+            pending.compactRendered
+                == """
+                Simulator route: CoreSimulator (Xcode 26 Simulator)
+                Attention: an interrupted change needs recovery. Run 'xcode-simulator-host status --verbose'.
+                """
+        )
+
+        let conflict = try makeStatus(
+            preferences: .deviceHub,
+            receiptStatus: .conflict(expected: .legacy, observed: .deviceHub)
+        )
+        #expect(
+            conflict.compactRendered
+                == """
+                Simulator route: Device Hub
+                Attention: preferences need review. Run 'xcode-simulator-host status --verbose'.
+                """
+        )
+    }
+
+    @Test func verboseStatusStartsWithTheRouteAndKeepsTechnicalDetails() throws {
+        let status = try makeStatus(
+            preferences: .deviceHub,
+            receiptStatus: .unmanaged
+        )
+
+        #expect(status.rendered.hasPrefix("Simulator route: Device Hub\n\n"))
+        #expect(status.rendered.contains("Selected Xcode: 27.0 (27A5252f)"))
+        #expect(status.rendered.contains("Legacy Simulator: Xcode 26.6"))
+        #expect(status.rendered.contains("Restoration receipt: none"))
+        #expect(status.rendered.contains("Running Xcode processes: 2"))
+        #expect(status.rendered.contains("CoreSimulator session: not set (default)"))
+        #expect(status.rendered.contains("Suppress Device Hub auto-start: not set (default)"))
+        #expect(!status.rendered.contains("Configured host:"))
+    }
+
+    private func makeStatus(
+        preferences: ManagedPreferenceState,
+        receiptStatus: ReceiptStatus
+    ) throws -> HostStatus {
+        let selectedXcode = XcodeInstallation(
+            applicationURL: URL(fileURLWithPath: "/Applications/Xcode_27.app"),
+            version: try ToolVersion("27.0"),
+            buildVersion: "27A5252f"
+        )
+        let legacyXcode = XcodeInstallation(
+            applicationURL: URL(fileURLWithPath: "/Applications/Xcode.app"),
+            version: try ToolVersion("26.6"),
+            buildVersion: "17F109"
+        )
+        return HostStatus(
+            xcode: selectedXcode,
+            preferences: preferences,
+            legacySimulator: SimulatorInstallation(
+                applicationURL: URL(
+                    fileURLWithPath: "/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app"
+                ),
+                xcode: legacyXcode,
+                version: "16.0",
+                buildVersion: "1063.4"
+            ),
+            receiptStatus: receiptStatus,
+            receiptURL: URL(
+                fileURLWithPath: "/Users/test/Library/Application Support/xcode-simulator-host/state.plist"
+            ),
+            runningXcodes: [
+                RunningApplication(
+                    processIdentifier: 9189,
+                    bundleURL: selectedXcode.applicationURL
+                ),
+                RunningApplication(
+                    processIdentifier: 54_923,
+                    bundleURL: legacyXcode.applicationURL
+                ),
+            ]
+        )
+    }
+}


### PR DESCRIPTION
## Purpose

The default `status` output currently makes the answer users need most—whether the next Xcode Run uses Device Hub or CoreSimulator—hard to find in a large diagnostic block.

Make that route immediately visible while keeping the existing diagnostic information available on demand.

## Changes

- Print exactly one route line for a normal `status` result: Device Hub or CoreSimulator using the Xcode 26 Simulator.
- Add `status --verbose` for Xcode installations, managed preferences, restoration state, and running Xcode processes.
- Read only the managed preference and restoration snapshot for compact status, so route reporting does not depend on Xcode discovery or installation validation.
- Keep interrupted or conflicting preference states actionable with one additional guidance line and the existing configuration exit code.
- Treat the existing `--legacy-xcode` status override as a verbose request and document the compact/verbose contract.

## Review focus

- Whether the managed preference snapshot is the correct owner of the compact route answer.
- Whether the compact safety warnings remain useful without reintroducing diagnostic noise.
- Whether compact and verbose acquisition preserve the existing receipt-locking and conflict behavior.

## Testing

- `DEVELOPER_DIR=/Applications/Xcode_27.app/Contents/Developer swift test` — 71 tests passed.
- `actionlint`
- `shellcheck scripts/*.sh`
- Built the arm64 release binary and verified the archive, checksums, generated installer, installation, and reported version with the release scripts.
- Manually verified compact and verbose output against the current Xcode 27/CoreSimulator configuration.
- Branch-wide Codex review against `main` completed with no findings.
