### PR TITLE
Recommend Legacy Simulator as the primary workflow

### DIFF
--- a/Documentation/AdvancedConfiguration.md
+++ b/Documentation/AdvancedConfiguration.md
@@ -1,10 +1,13 @@
 # Advanced configuration
 
-The default workflow requires only:
+The recommended workflow uses Apple's validated Xcode 26 `Simulator.app`:
 
 ```console
-xcode-simulator-host use neo
+xcode-simulator-host use legacy
 ```
+
+The packaged `NeoSimulator` host is under active development and currently in
+beta. Select it with `xcode-simulator-host use neo`.
 
 ## Detailed status
 
@@ -20,7 +23,7 @@ Verbose status reports:
   `simctl`, `devicectl`, and simulator CoreDevice plugin paths and versions;
 - the discovered or explicitly selected Xcode 26 `Simulator.app`;
 - restoration receipt state;
-- running Xcode, Neo, and legacy Simulator processes;
+- running Xcode, legacy Simulator, and Neo processes;
 - exact managed preference values.
 
 `status` and `status --verbose` are read-only. Compact status reports only the
@@ -36,7 +39,14 @@ DEVELOPER_DIR=/Applications/Xcode_28.app/Contents/Developer \
   xcode-simulator-host status --verbose
 ```
 
-Use the same environment for a mutation:
+Use the same environment with the recommended Legacy host:
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode_28.app/Contents/Developer \
+  xcode-simulator-host use legacy
+```
+
+To evaluate the beta Neo host with that Xcode instead:
 
 ```bash
 DEVELOPER_DIR=/Applications/Xcode_28.app/Contents/Developer \
@@ -79,7 +89,7 @@ The managed Xcode preferences are shared by all installed Xcode versions.
 Selecting an installation changes which Xcode supplies Neo's private
 frameworks; it does not create installation-specific preference state.
 
-Neo and Legacy share one CoreSimulator preference state. Switching between
+Legacy and Neo share one CoreSimulator preference state. Switching between
 them changes process ownership even when no preference write is needed.
 
 ## Recovery
@@ -100,7 +110,7 @@ xcode-simulator-host restore --force
 `--force` lets the saved original Boolean state win over a conflicting live
 Boolean state. It still rejects malformed or non-Boolean preferences.
 
-The receipt records preferences, not whether Neo or Legacy was last selected.
+The receipt records preferences, not whether Legacy or Neo was last selected.
 Restoring an original CoreSimulator route therefore does not guess which UI
 host to launch.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # xcode-simulator-host
 
-Use iOS Simulator from Xcode 27 or later through CoreSimulator, without making
+Use iOS Simulator from Xcode 27+ through CoreSimulator, without making
 Device Hub the display host.
+
+> [!IMPORTANT]
+> `use legacy` with Apple's `Simulator.app` from Xcode 26 is the recommended
+> host. The packaged `NeoSimulator` host is under active development and is
+> currently in beta.
 
 ## Why
 
@@ -10,48 +15,29 @@ Hub, but CoreSimulator still owns the simulated devices used by Build & Run.
 This package makes that direct CoreSimulator route usable again and lets you
 choose the UI that presents it.
 
-## What
+## Host Choices
 
 `xcode-simulator-host` provides three explicit host choices:
 
-| Command | UI host | Intended use |
+| Command | UI host | Status and intended use |
 | --- | --- | --- |
-| `use neo` | Packaged `NeoSimulator` app | Use the selected Xcode 27+ installation without needing an older Xcode |
-| `use legacy` | Apple's `Simulator.app` from Xcode 26 | Keep the complete older Simulator UI when Xcode 26 is installed |
+| `use legacy` | Apple's `Simulator.app` from Xcode 26 | **Recommended.** Keep the complete Simulator UI while using Xcode 27+ for Build & Run |
+| `use neo` | Packaged `NeoSimulator` app | **Beta.** Try the standalone host under active development without needing an older Xcode |
 | `use device-hub` | Device Hub from the selected Xcode | Return to Xcode's default behavior |
 
-Neo and Legacy both select the same direct CoreSimulator preference route; the
+Legacy and Neo both select the same direct CoreSimulator preference route; the
 difference is the process that presents the simulator. The restoration receipt
 therefore owns preference recovery, not a remembered UI-host choice.
 
-Neo provides:
-
-- one resizable window for each booted iOS simulator;
-- device bezel, touch, accessibility, and focused keyboard input;
-- Home, Save Screen, Rotate Right, and Software Keyboard controls in the
-  window header;
-- File, Device, I/O, Features, and Window menus modeled after Simulator.app;
-- Home, Lock, Shake, rotation, appearance, bezel, Stay on Top, Fit Screen, and
-  standard window commands.
-
-Neither `use neo` nor `use legacy` launches Device Hub. If the exact Device Hub
-process cannot be closed, the requested UI host is not opened. While Neo is
-running, it also exits if Device Hub or a legacy `Simulator.app` appears, so two
-UI hosts cannot own the same simulator session.
-
 ## Requirements
 
-- macOS 26.4 or later
-- Xcode 27 or later as the selected Build & Run installation
-- Apple Silicon when installing a prebuilt release
-- Swift 6.4 when building from source
-- Xcode 26 only when using `use legacy`
+- macOS 26.4+
+- Apple Silicon
+- Xcode 27+
+- Xcode 26 (`use legacy`)
+- Swift 6.4+ (source builds)
 
-Later Xcode versions are accepted by Neo only when their private CoreSimulator,
-SimulatorKit, CoreDevice, and command-tool surfaces pass the compatibility gate.
-An incompatible version fails closed; Neo never falls back to Device Hub.
-
-## Quick Start
+## Recommended Quick Start: Simulator.app from Xcode 26
 
 Install the latest prebuilt release:
 
@@ -62,27 +48,20 @@ curl -fsSL https://github.com/lynnswap/xcode-simulator-host/releases/latest/down
 Follow the printed PATH guidance if needed, then run:
 
 ```bash
-xcode-simulator-host use neo
-```
-
-Keep Xcode open and use **Build & Run** as usual. Neo waits for booted iOS
-simulators and opens their windows automatically.
-
-Running `use neo` again is safe. It revalidates and restarts the exact packaged
-host with the currently selected Xcode, so switching between compatible Xcode
-27+ installations cannot leave a host using frameworks from the previous
-selection.
-
-## Use Simulator.app from Xcode 26
-
-When Xcode 26 is installed in `/Applications`, the highest validated Xcode 26
-version is selected automatically:
-
-```bash
 xcode-simulator-host use legacy
 ```
 
-To choose a specific installation:
+When Xcode 26 is installed in `/Applications`, the highest validated Xcode 26
+version is selected automatically. Keep the selected Xcode 27+ installation
+open and use **Build & Run** as usual; Xcode 26 supplies only the Simulator UI.
+
+Running `use legacy` again is safe. The exact validated `Simulator.app` is
+closed and reopened without rewriting an already-correct CoreSimulator route.
+
+### Choose a Specific Xcode 26 Installation
+
+To use an Xcode 26 installation outside `/Applications`, or to choose one
+explicitly:
 
 ```bash
 xcode-simulator-host use legacy \
@@ -91,8 +70,35 @@ xcode-simulator-host use legacy \
 
 `--legacy-xcode` selects only the legacy UI host. Build & Run still uses the
 Xcode 27+ installation selected through `DEVELOPER_DIR` or `xcode-select`.
-Running the command again is safe: the exact validated `Simulator.app` is
-closed and reopened without rewriting an already-correct CoreSimulator route.
+
+## Try NeoSimulator (Beta)
+
+`NeoSimulator` is an alternative host currently in beta and under active
+development. It uses the selected Xcode 27+ installation and does not require
+Xcode 26.
+
+```bash
+xcode-simulator-host use neo
+```
+
+Neo currently provides:
+
+- one resizable window for each booted iOS simulator;
+- device bezel, touch, accessibility, and focused keyboard input;
+- Home, Save Screen, Rotate Right, and Software Keyboard controls in the
+  window header;
+- File, Device, I/O, Features, and Window menus modeled after Simulator.app;
+- Home, Lock, Shake, rotation, appearance, bezel, Stay on Top, Fit Screen, and
+  standard window commands.
+
+Later Xcode versions are accepted only when their private CoreSimulator,
+SimulatorKit, CoreDevice, and command-tool surfaces pass the compatibility gate.
+An incompatible version fails closed; Neo never falls back to Device Hub.
+
+Running `use neo` again is safe. It revalidates and restarts the exact packaged
+host with the currently selected Xcode, so switching between compatible Xcode
+27+ installations cannot leave a host using frameworks from the previous
+selection.
 
 ## Return to Device Hub
 
@@ -100,7 +106,7 @@ closed and reopened without rewriting an already-correct CoreSimulator route.
 xcode-simulator-host use device-hub
 ```
 
-Neo and validated legacy Simulator processes close before the default Device
+Validated legacy Simulator and Neo processes close before the default Device
 Hub route is enabled.
 
 ## Restore the Original Settings
@@ -111,7 +117,7 @@ xcode-simulator-host restore
 
 Use `restore` to undo the tool's preference changes instead of guessing which
 route was originally configured. If the saved original route is CoreSimulator,
-`restore` does not guess whether Neo or Legacy should be opened.
+`restore` does not guess whether Legacy or Neo should be opened.
 
 ## Inspect the Current Route
 
@@ -120,7 +126,7 @@ xcode-simulator-host status
 ```
 
 Compact status reports `CoreSimulator` or `Device Hub`. It cannot distinguish
-Neo from Legacy because those hosts intentionally share the same preference
+Legacy from Neo because those hosts intentionally share the same preference
 route.
 
 For host availability, selected Xcode details, compatibility-checked private
@@ -137,19 +143,25 @@ Both commands are read-only. See
 ## Safety and Recovery
 
 > [!IMPORTANT]
-> Neo uses undocumented Apple frameworks and Xcode preferences. Legacy launches
-> an intact Apple-signed `Simulator.app` from a validated Xcode 26 installation.
+> Both direct-host modes use undocumented Xcode preferences. Legacy launches an
+> intact Apple-signed `Simulator.app` from a validated Xcode 26 installation.
+> The beta Neo host also uses undocumented Apple frameworks.
+
+Neither `use legacy` nor `use neo` launches Device Hub. If the exact Device Hub
+process cannot be closed, the requested UI host is not opened. While Neo is
+running, it also exits if Device Hub or a legacy `Simulator.app` appears, so two
+UI hosts cannot own the same simulator session.
 
 Before changing preferences, every `use` command validates the selected Xcode
 27+ installation, the preference surfaces, and the exact Device Hub identity.
 Additional host-specific gates run before any process or preference mutation:
 
-- `use neo` validates the installed CoreSimulator/CoreDevice generations,
-  direct tools and plugin, the packaged NeoSimulator identity, and the exact
-  private runtime contract used by the GUI process;
 - `use legacy` validates the outer Xcode 26 application, its version and Apple
   signature, and the nested `Simulator.app` identity, `DTXcode`, executable,
-  and Apple signature.
+  and Apple signature;
+- `use neo` validates the installed CoreSimulator/CoreDevice generations,
+  direct tools and plugin, the packaged NeoSimulator identity, and the exact
+  private runtime contract used by the GUI process.
 
 Preference changes are journaled and verified. A conflicting external change
 is left untouched unless the user explicitly runs `restore --force`.
@@ -164,9 +176,9 @@ Do not run mutation commands with `sudo`; preferences and recovery state are
 per-user. Run `restore` before uninstalling the command or deleting its state.
 
 See the [design and safety contract](Documentation/Design.md), the
-[NeoSimulator contract](Documentation/StandaloneHost.md), and the
-[Simulator.app analysis](Documentation/SimulatorAppAnalysis.md) for exact
-owners and exclusions.
+[Simulator.app analysis](Documentation/SimulatorAppAnalysis.md), and the
+[NeoSimulator contract](Documentation/StandaloneHost.md) for exact owners and
+exclusions.
 
 ## Install to a Custom Directory
 
@@ -175,9 +187,9 @@ curl -fsSL https://github.com/lynnswap/xcode-simulator-host/releases/latest/down
   | sh -s -- --bindir "$HOME/bin"
 ```
 
-The installer keeps the CLI and NeoSimulator app in a fixed relative layout. It
-resolves a symlinked bindir to its physical directory, then stages and verifies
-both before replacing an existing installation.
+The installer keeps the CLI and bundled beta NeoSimulator app in a fixed
+relative layout. It resolves a symlinked bindir to its physical directory, then
+stages and verifies both before replacing an existing installation.
 
 ## Build from Source
 
@@ -188,9 +200,18 @@ scripts/build-local.sh
 .build/local/arm64/bin/xcode-simulator-host --help
 ```
 
-The source build uses SwiftPM for the CLI and the `NeoSimulator` app
+The source build uses SwiftPM for the CLI and the beta `NeoSimulator` app
 target in `xcode-simulator-host.xcworkspace`. The staging script puts both
 products in the same relative layout used by releases.
+
+Build and switch to the recommended Legacy host in one command:
+
+```bash
+scripts/build-local.sh && .build/local/arm64/bin/xcode-simulator-host use legacy
+```
+
+This runs from the repo-local staging directory; it does not install the command
+into `PATH`. Use `use neo` instead to try the locally built beta host.
 
 Run the isolated test suite with:
 


### PR DESCRIPTION
## Purpose

NeoSimulator remains under active development, but the user-facing documentation presented it as the primary workflow. Make Apple's validated Xcode 26 `Simulator.app` the recommended host while keeping NeoSimulator available as a clearly labeled beta.

## Changes

- Reorder the README around the recommended Legacy quick start and move NeoSimulator commands, capabilities, and compatibility details into a dedicated Beta section.
- Simplify the requirements and document the repo-local build-and-run workflow with Legacy as the primary host.
- Align the advanced configuration guide with the same Legacy-first workflow and keep the beta Neo selection explicit.

## Testing

- `git diff --check main...HEAD`
- `codex-review --base main` (no findings)
