### PR TITLE
Accept Mac App Store Xcode as a legacy Simulator host

### DIFF
--- a/Sources/XcodeSimulatorHost/System/CodeSignatureValidator.swift
+++ b/Sources/XcodeSimulatorHost/System/CodeSignatureValidator.swift
@@ -18,23 +18,56 @@ struct CodeSignatureValidator: Sendable {
             try checkAppleCodeSignature(
                 at: codeURL,
                 identifier: identifier,
-                requiresApplicationForm: false
+                policy: .code
             )
         },
         validateAppleApplication: { applicationURL, identifier in
             try checkAppleCodeSignature(
                 at: applicationURL,
                 identifier: identifier,
-                requiresApplicationForm: true
+                policy: .application
             )
         }
     )
 }
 
+enum AppleCodeValidationPolicy: Sendable {
+    case code
+    case application
+
+    func requirement(for identifier: String) -> String {
+        switch self {
+        case .code:
+            return #"identifier "\#(identifier)" and anchor apple"#
+        case .application:
+            return #"identifier "\#(identifier)" and (anchor apple or (anchor apple generic and certificate leaf[field.1.2.840.113635.100.6.1.9] exists))"#
+        }
+    }
+
+    var validationFlags: SecCSFlags {
+        var rawFlags = kSecCSCheckAllArchitectures
+            | kSecCSStrictValidate
+            | kSecCSRestrictSymlinks
+        if self == .application {
+            rawFlags |= kSecCSRestrictToAppLike
+        }
+        return SecCSFlags(rawValue: rawFlags)
+    }
+
+    var description: String {
+        switch self {
+        case .code:
+            return "code"
+        case .application:
+            return "application"
+        }
+    }
+}
+
 private func checkAppleCodeSignature(
     at codeURL: URL,
     identifier: String,
-    requiresApplicationForm: Bool
+    policy: AppleCodeValidationPolicy
 ) throws {
     var staticCode: SecStaticCode?
     let createStatus = SecStaticCodeCreateWithPath(
@@ -50,7 +83,7 @@ private func checkAppleCodeSignature(
     }
 
     var requirement: SecRequirement?
-    let requirementText = "identifier \"\(identifier)\" and anchor apple" as CFString
+    let requirementText = policy.requirement(for: identifier) as CFString
     let requirementStatus = SecRequirementCreateWithString(
         requirementText,
         SecCSFlags(),
@@ -63,22 +96,15 @@ private func checkAppleCodeSignature(
         )
     }
 
-    var rawFlags = kSecCSCheckAllArchitectures
-        | kSecCSStrictValidate
-        | kSecCSRestrictSymlinks
-    if requiresApplicationForm {
-        rawFlags |= kSecCSRestrictToAppLike
-    }
     let validationStatus = SecStaticCodeCheckValidity(
         staticCode,
-        SecCSFlags(rawValue: rawFlags),
+        policy.validationFlags,
         requirement
     )
     guard validationStatus == errSecSuccess else {
-        let kind = requiresApplicationForm ? "application" : "code"
         throw CLIError.unavailable(
             "code-signature",
-            "\(codeURL.path) is not intact Apple-signed \(kind) with identifier \(identifier): \(securityMessage(validationStatus))"
+            "\(codeURL.path) is not intact Apple-signed \(policy.description) with identifier \(identifier): \(securityMessage(validationStatus))"
         )
     }
 }

--- a/Tests/XcodeSimulatorHostTests/CodeSignatureValidatorTests.swift
+++ b/Tests/XcodeSimulatorHostTests/CodeSignatureValidatorTests.swift
@@ -1,0 +1,255 @@
+import Foundation
+import Security
+import Testing
+
+@testable import XcodeSimulatorHost
+
+@Suite
+struct CodeSignatureValidatorTests {
+    @Test func liveValidationAcceptsApplePlatformSigningAndExactIdentity() throws {
+        let calculatorURL = URL(
+            fileURLWithPath: "/System/Applications/Calculator.app",
+            isDirectory: true
+        )
+        try requireValidApplication(
+            at: calculatorURL,
+            satisfying: #"identifier "com.apple.calculator" and anchor apple"#
+        )
+
+        try CodeSignatureValidator.live.validateAppleApplication(
+            calculatorURL,
+            "com.apple.calculator"
+        )
+    }
+
+    @Test func liveValidationRejectsAnIdentityMismatch() throws {
+        let calculatorURL = URL(
+            fileURLWithPath: "/System/Applications/Calculator.app",
+            isDirectory: true
+        )
+        try requireValidApplication(
+            at: calculatorURL,
+            satisfying: #"identifier "com.apple.calculator" and anchor apple"#
+        )
+
+        #expect(throws: CLIError.self) {
+            try CodeSignatureValidator.live.validateAppleApplication(
+                calculatorURL,
+                "com.example.NotCalculator"
+            )
+        }
+    }
+
+    @Test func liveValidationRejectsAdHocSignedApplications() throws {
+        let directory = try TemporaryTestDirectory()
+        let applicationURL = directory.url.appendingPathComponent(
+            "AdHoc.app",
+            isDirectory: true
+        )
+        let contentsURL = applicationURL.appendingPathComponent(
+            "Contents",
+            isDirectory: true
+        )
+        let executableURL = contentsURL.appendingPathComponent(
+            "MacOS/AdHoc",
+            isDirectory: false
+        )
+        try FileManager.default.createDirectory(
+            at: executableURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.copyItem(
+            at: URL(fileURLWithPath: "/usr/bin/true"),
+            to: executableURL
+        )
+        let info = [
+            "CFBundleIdentifier": "com.example.AdHoc",
+            "CFBundleExecutable": "AdHoc",
+            "CFBundlePackageType": "APPL",
+        ]
+        let infoData = try PropertyListSerialization.data(
+            fromPropertyList: info,
+            format: .xml,
+            options: 0
+        )
+        try infoData.write(
+            to: contentsURL.appendingPathComponent("Info.plist")
+        )
+        try runCodeSign(
+            ["--force", "--sign", "-", applicationURL.path]
+        )
+        try requireValidApplication(at: applicationURL)
+
+        #expect(throws: CLIError.self) {
+            try CodeSignatureValidator.live.validateAppleApplication(
+                applicationURL,
+                "com.example.AdHoc"
+            )
+        }
+    }
+
+    @Test(
+        .enabled(
+            if: macAppStoreFixture != nil,
+            "Set NEOSIMULATOR_TEST_MAC_APP_STORE_APPLICATION and NEOSIMULATOR_TEST_MAC_APP_STORE_IDENTIFIER to run against an intact Mac App Store application"
+        )
+    )
+    func liveValidationAcceptsMacAppStoreSigning() throws {
+        let fixture = try #require(macAppStoreFixture)
+        try requireValidApplication(
+            at: fixture.applicationURL,
+            satisfying: #"identifier "\#(fixture.identifier)" and anchor apple generic and certificate leaf[field.1.2.840.113635.100.6.1.9] exists"#
+        )
+
+        try CodeSignatureValidator.live.validateAppleApplication(
+            fixture.applicationURL,
+            fixture.identifier
+        )
+        #expect(throws: CLIError.self) {
+            try CodeSignatureValidator.live.validateAppleApplication(
+                fixture.applicationURL,
+                "com.example.IdentityMismatch"
+            )
+        }
+        #expect(throws: CLIError.self) {
+            try CodeSignatureValidator.live.validateAppleCode(
+                fixture.applicationURL,
+                fixture.identifier
+            )
+        }
+    }
+
+    @Test(
+        .enabled(
+            if: developerIDFixture != nil,
+            "Set NEOSIMULATOR_TEST_DEVELOPER_ID_APPLICATION and NEOSIMULATOR_TEST_DEVELOPER_ID_IDENTIFIER to run against an intact Developer ID application"
+        )
+    )
+    func liveValidationRejectsDeveloperIDSigning() throws {
+        let fixture = try #require(developerIDFixture)
+        try requireValidApplication(
+            at: fixture.applicationURL,
+            satisfying: #"identifier "\#(fixture.identifier)" and anchor apple generic"#
+        )
+
+        #expect(throws: CLIError.self) {
+            try CodeSignatureValidator.live.validateAppleApplication(
+                fixture.applicationURL,
+                fixture.identifier
+            )
+        }
+    }
+
+    @Test func codeValidationRemainsRestrictedToApplePlatformSigning() {
+        #expect(
+            AppleCodeValidationPolicy.code.requirement(
+                for: "com.example.Code"
+            ) == #"identifier "com.example.Code" and anchor apple"#
+        )
+    }
+
+    @Test func applicationValidationAcceptsOnlyAppleOfficialSigningForms() {
+        #expect(
+            AppleCodeValidationPolicy.application.requirement(
+                for: "com.example.Application"
+            ) == #"identifier "com.example.Application" and (anchor apple or (anchor apple generic and certificate leaf[field.1.2.840.113635.100.6.1.9] exists))"#
+        )
+    }
+
+    @Test func validationPoliciesPreserveIntegrityAndApplicationFormChecks() {
+        let commonFlags = kSecCSCheckAllArchitectures
+            | kSecCSStrictValidate
+            | kSecCSRestrictSymlinks
+
+        #expect(
+            AppleCodeValidationPolicy.code.validationFlags.rawValue
+                == commonFlags
+        )
+        #expect(
+            AppleCodeValidationPolicy.application.validationFlags.rawValue
+                == commonFlags | kSecCSRestrictToAppLike
+        )
+    }
+
+    @Test func codeRequirementsCompile() {
+        for policy in [
+            AppleCodeValidationPolicy.code,
+            AppleCodeValidationPolicy.application,
+        ] {
+            var requirement: SecRequirement?
+            let status = SecRequirementCreateWithString(
+                policy.requirement(for: "com.example.Code") as CFString,
+                SecCSFlags(),
+                &requirement
+            )
+
+            #expect(status == errSecSuccess)
+            #expect(requirement != nil)
+        }
+    }
+
+    private func runCodeSign(_ arguments: [String]) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
+        process.arguments = arguments
+        try process.run()
+        process.waitUntilExit()
+        try #require(process.terminationStatus == 0)
+    }
+
+    private func requireValidApplication(
+        at applicationURL: URL,
+        satisfying requirementSource: String? = nil
+    ) throws {
+        var staticCode: SecStaticCode?
+        let createStatus = SecStaticCodeCreateWithPath(
+            applicationURL as CFURL,
+            SecCSFlags(),
+            &staticCode
+        )
+        try #require(createStatus == errSecSuccess)
+        let code = try #require(staticCode)
+
+        var requirement: SecRequirement?
+        if let requirementSource {
+            let requirementStatus = SecRequirementCreateWithString(
+                requirementSource as CFString,
+                SecCSFlags(),
+                &requirement
+            )
+            try #require(requirementStatus == errSecSuccess)
+            _ = try #require(requirement)
+        }
+
+        let validationStatus = SecStaticCodeCheckValidity(
+            code,
+            AppleCodeValidationPolicy.application.validationFlags,
+            requirement
+        )
+        try #require(validationStatus == errSecSuccess)
+    }
+}
+
+private let macAppStoreFixture: (applicationURL: URL, identifier: String)? = {
+    let environment = ProcessInfo.processInfo.environment
+    guard let applicationPath =
+            environment["NEOSIMULATOR_TEST_MAC_APP_STORE_APPLICATION"],
+          let identifier =
+            environment["NEOSIMULATOR_TEST_MAC_APP_STORE_IDENTIFIER"]
+    else {
+        return nil
+    }
+    return (URL(fileURLWithPath: applicationPath, isDirectory: true), identifier)
+}()
+
+private let developerIDFixture: (applicationURL: URL, identifier: String)? = {
+    let environment = ProcessInfo.processInfo.environment
+    guard let applicationPath =
+            environment["NEOSIMULATOR_TEST_DEVELOPER_ID_APPLICATION"],
+          let identifier =
+            environment["NEOSIMULATOR_TEST_DEVELOPER_ID_IDENTIFIER"]
+    else {
+        return nil
+    }
+    return (URL(fileURLWithPath: applicationPath, isDirectory: true), identifier)
+}()


### PR DESCRIPTION
## Purpose

`use legacy` rejected an intact Xcode 26 installation from the Mac App Store because application validation recognized only Apple platform signing. Accept both official Xcode distribution channels without widening validation to Developer ID, ad hoc, re-signed, or identity-mismatched applications.

Closes #9.

## Changes

- Give application signature validation an explicit policy that requires the expected identifier and accepts either Apple platform signing or the Mac App Store application certificate OID under `anchor apple generic`.
- Keep framework, plugin, and direct-tool validation restricted to `anchor apple`, and preserve strict bundle, all-architecture, symlink, and app-form checks.
- Add requirement compilation and flag regression tests, plus live Security framework tests for Apple platform, Mac App Store, Developer ID, ad hoc, and identity-mismatch cases. Live external fixtures are prevalidated with the same integrity and app-form flags before the production policy is evaluated.

## Review focus

- Confirm that the expected identifier applies to both allowed signer alternatives and that the Mac App Store branch is limited to Apple-issued Mac App Store application certificates.
- Confirm that non-application Apple code validation and all existing integrity flags remain unchanged.

## Testing

- `swift test` — 123 passed; the two environment-gated external-signature tests skipped in the default run.
- `NEOSIMULATOR_TEST_MAC_APP_STORE_APPLICATION=/Applications/Numbers.app NEOSIMULATOR_TEST_MAC_APP_STORE_IDENTIFIER=com.apple.iWork.Numbers NEOSIMULATOR_TEST_DEVELOPER_ID_APPLICATION=/Applications/Claude.app NEOSIMULATOR_TEST_DEVELOPER_ID_IDENTIFIER=com.anthropic.claudefordesktop swift test --filter CodeSignatureValidatorTests` — all 9 tests passed, including Mac App Store acceptance and Developer ID rejection through `CodeSignatureValidator.live`.
- `scripts/build-local.sh`
- `.build/local/arm64/bin/xcode-simulator-host status --verbose --legacy-xcode /Applications/Xcode.app` — validated the selected Xcode 27 installation, the Developer Downloads Xcode 26.6 installation and nested Simulator, and the packaged host without changing state.
- `git diff --check`
- Base-pinned branch-wide Codex review against `main` reported no findings.

The Mac App Store requirement follows [TN3127: Inside Code Signing: Requirements](https://developer.apple.com/documentation/technotes/tn3127-inside-code-signing-requirements).
